### PR TITLE
iterating through an array in renderInternal function/skin.js

### DIFF
--- a/modules/ringo/skin.js
+++ b/modules/ringo/skin.js
@@ -171,9 +171,9 @@ function Skin(mainSkin, subSkins, parentSkin, resourceOrString) {
 
     function renderInternal(parts, context) {
         var renderedParts = [];
-	for(var i=0,l=parts.length;i<l;i++){
-		renderedParts.push(renderPart(parts[i],context));
-	}
+        for(var i=0,l=parts.length;i<l;i++){
+                renderedParts.push(renderPart(parts[i],context));
+        }
         var value = renderedParts.join('');
         if (parts && parts.subskinFilter) {
             return evaluateFilter(value, parts.subskinFilter, context);


### PR DESCRIPTION
i was trying to add mootools inside my ringo app, and i discovered a problem in the skin.
on line 173 in renderInternal method, we have:
var value = [renderPart(part, context) for each (part in parts)].join('');
moootools unfortunately pollutes global Array object.
and when iterating with in in the parts Array, one gets mootools functions too.
let's say i remove mootools, but still extend Array with a function that my app needs, i would still be in trouble.
check this example: https://gist.github.com/674102 , runnable inside ringo shell.
