### PR TITLE
accept username:password type url in httpclient request

### DIFF
--- a/modules/ringo/httpclient.js
+++ b/modules/ringo/httpclient.js
@@ -371,7 +371,8 @@ var Exchange = function(url, options, callbacks) {
     if (userInfo) {
         // exchange.setURL does not take username:password in URL
         url = url.replace(userInfo + "@", "");
-        var [options.username, password] = userInfo.split(":");
+        var [username, password] = userInfo.split(":");
+        options.username = options.username || username;
         options.password = options.password || password;
     }    
 

--- a/test/ringo/httpclient_test.js
+++ b/test/ringo/httpclient_test.js
@@ -3,6 +3,7 @@ var {Client, request, post, get, put, del} = require('ringo/httpclient');
 var {Server} = require('ringo/httpserver');
 var {Request} = require('ringo/webapp/request');
 var {Response} = require('ringo/webapp/response');
+var base64 = require('ringo/base64');
 
 var server;
 var host = "127.0.0.1";
@@ -121,7 +122,14 @@ exports.testUserInfo = function() {
     assert.equal(log.length, 1, "user - one request");
     assert.equal(log[0].length, 1, "user - one Authorization header");
     assert.equal(log[0][0].slice(0, 5), "Basic", "user - Basic auth header");
-    
+
+    // username and password in url, options take precedence
+    log = [];
+    request({url: "http://user:pass@" + host + ":" + port + "/", username: "realuser", password: "realpass"});
+    assert.equal(log.length, 1, "precedence - one request");
+    assert.equal(log[0].length, 1, "precedence - one Authorization header");
+    assert.equal(log[0][0], "Basic " + base64.encode("realuser:realpass"), "precedence - Basic auth header");
+
 }
 
 /**


### PR DESCRIPTION
When provided a URL like http://username:password@example.com, the request method in httpclient throws.  Instead, the credentials could be pulled from the URL and included in an Authorization header.

Not sure if you'll want your history to show all these commits, but the result is two changed files (httpclient.js and httpclient_test.js).
