### PR TITLE
Maven Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target
 *.iml
 *.ipr
 *.iws
+.idea

--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   RingoJS uses a newer version of Rhino than the one that can currently be found
-  in Maven's central repository (1.7R2).
+  in Maven's central repository.
 
-  To add the RingoJS version of Rhino to your local repository, run this command
-  from the RingoJS root folder:
+  To add the RingoJS version of Rhino to your local repository, run the following command
+  from the RingoJS root folder. Ideally, your company runs there own repository and an SCM
+  admin can install the artifact there for the whole company to benefit. The Mozilla team
+  are now working towards getting the 1.7R3 version deployed to the central repository, so
+  this step will soon be moot.
 
-      mvn install:install-file -Dfile=lib/js.jar -DgroupId=org.ringojs \
-       -DartifactId=rhino-js -Dversion=1.7R3-SNAPSHOT -Dpackaging=jar
+      mvn install:install-file -Dfile=lib/js.jar -DgroupId=org.mozilla \
+       -DartifactId=rhino -Dversion=1.7R3 -Dpackaging=jar
+
+  Next, we need to get RingoJS added to the central repository. :)
+
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -16,7 +22,7 @@
 
     <groupId>org.ringojs</groupId>
     <artifactId>ringojs</artifactId>
-    <version>0.7.0</version>
+    <version>0.8.0-SNAPSHOT</version>
 
     <packaging>jar</packaging>
 
@@ -41,7 +47,6 @@
         <connection>scm:git:git://github.com/ringo/ringojs.git</connection>
         <developerConnection>scm:git:git@github.com:ringo/ringojs.git</developerConnection>
     </scm>
-
 
     <developers>
         <developer>
@@ -119,12 +124,12 @@
         <jetty-version>7.1.6.v20100715</jetty-version>
         <slf4j-version>1.6.1</slf4j-version>
         <log4j-version>1.2.16</log4j-version>
-        <rhino-version>1.7R3-SNAPSHOT</rhino-version>
+        <rhino-version>1.7R3</rhino-version>
         <junit-version>3.8.2</junit-version>
-        <jnr-posix-version>1.1.5</jnr-posix-version>
+        <jnr-posix-version>1.1.8</jnr-posix-version>
         <constantine-version>0.7</constantine-version>
-        <jffi-version>1.0.5</jffi-version>
-        <jaffl-version>0.5.7</jaffl-version>
+        <jffi-version>1.0.10</jffi-version>
+        <jaffl-version>0.5.10</jaffl-version>
         <jline-version>0.9.94</jline-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
@@ -144,8 +149,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.ringojs</groupId>
-            <artifactId>rhino-js</artifactId>
+            <groupId>org.mozilla</groupId>
+            <artifactId>rhino</artifactId>
             <version>${rhino-version}</version>
         </dependency>
 
@@ -247,7 +252,7 @@
 
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
-                <!--<version>2.4.3</version>-->
+                <version>2.5</version>
                 <executions>
                     <execution>
                         <id>copy-resources</id>
@@ -270,6 +275,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>2.3.1</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -283,6 +289,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
                 <configuration>
                     <source>1.5</source>
                     <target>1.5</target>
@@ -315,6 +322,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+                <version>2.1.2</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -335,16 +343,19 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-changelog-plugin</artifactId>
+                <version>2.2</version>
             </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jxr-plugin</artifactId>
+                <version>2.2</version>
             </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>
+                <version>2.5</version>
                 <configuration>
                     <targetJdk>1.5</targetJdk>
                 </configuration>
@@ -353,6 +364,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.8</version>
                 <configuration>
                     <source>1.5</source>
                 </configuration>
@@ -361,13 +373,13 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.4</version>
+                <version>2.5.1</version>
                 <configuration>
-                  <instrumentation>
-                    <excludes>
-                      <exclude>org/ringojs/test/**</exclude>
-                    </excludes>
-                  </instrumentation>
+                    <instrumentation>
+                        <excludes>
+                            <exclude>org/ringojs/test/**</exclude>
+                        </excludes>
+                    </instrumentation>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
The Mozilla team has indicated that they will add Rhino 1.7R3 to the central repository soon, so I updated the groupId and artifactId to reflect their new expected naming convention for the Rhino library.

Also, updated the Maven dependency versions for jnr-posix, jffi and jaffl to the most recent releases.

RingoJS uses a newer version of Rhino than the one that can currently be found in Maven's central repository.

To add the RingoJS version of Rhino to your local repository, run the following command from the RingoJS root folder. Ideally, your company runs their own repository, and an SCM admin can install the artifact there for the whole company to benefit. The Mozilla team are now working towards getting the 1.7R3 version deployed to the central repository, so this step will soon be moot.

```
      mvn install:install-file -Dfile=lib/js.jar -DgroupId=org.mozilla \
       -DartifactId=rhino -Dversion=1.7R3 -Dpackaging=jar
```

Next, we need to get RingoJS added to the central repository. :)
