### PR TITLE
Params with same name return array of values

### DIFF
--- a/modules/ringo/utils/http.js
+++ b/modules/ringo/utils/http.js
@@ -363,8 +363,16 @@ function mergeParameter(params, name, value) {
         var names = name.split(/\]\s*\[|\[|\]/).map(function(s) s.trim()).slice(0, -1);
         mergeParameterInternal(params, names, value);
     } else {
-        // not matching the foo[bar] pattern, add param as is
-        params[name] = value;
+        // not matching the foo[bar] pattern, add param as is. If there is another param with the
+        // same name, we need to create an array.
+        if (params[name]) {
+            if (Array.isArray(params[name])) params[name].push(value);
+            else {
+                params[name] = [].concat(params[name]).concat(value);
+            }
+        } else {
+            params[name] = value;
+        }
     }
 }
 

--- a/test/ringo/utils/http_test.js
+++ b/test/ringo/utils/http_test.js
@@ -10,3 +10,29 @@ exports.testUrlEncode = function() {
     expected = "foo=1&foo=2&foo=3&foo=4&foo=5&bar=baz";
     assert.strictEqual(encoded, expected);
 };
+
+exports.testParseParameters = function() {
+    var result;
+
+    result = http.parseParameters('foo1=val1&foo2=val2');
+    assert.isNotUndefined(result.foo1);
+    assert.isNotUndefined(result.foo2);
+    assert.strictEqual(result.foo1, 'val1');
+    assert.strictEqual(result.foo2, 'val2');
+
+    result = http.parseParameters('foo[]=1&foo[]=2&foo[]=3&foo[]=4&foo[]=5&bar=baz');
+    assert.isNotUndefined(result.foo);
+    assert.isNotUndefined(result.bar);
+    assert.isTrue(Array.isArray(result.foo));
+    assert.strictEqual(result.foo.length, 5);
+    assert.strictEqual(result.foo.sort().join(','), '1,2,3,4,5');
+    assert.strictEqual(result.bar, 'baz');
+
+    result = http.parseParameters('foo=1&foo=2&foo=3&foo=4&foo=5&bar=baz');
+    assert.isNotUndefined(result.foo);
+    assert.isNotUndefined(result.bar);
+    assert.isTrue(Array.isArray(result.foo));
+    assert.strictEqual(result.foo.length, 5);
+    assert.strictEqual(result.foo.sort().join(','), '1,2,3,4,5');
+    assert.strictEqual(result.bar, 'baz');
+};


### PR DESCRIPTION
Fixed a problem when parsing parameters with the same name were not creating an array of values.

According to the servlet spec, multiple query parameters with the same name should be returned as an array of values. There may be an RFC spec to back this up as well, since most people name there checkboxes with the same name value.

```
foo=1&foo=2&foo=3
should return 
{ 'foo' : [ '1', '2', '3' ] }
```

The current implementation only returns { 'foo': '3' }. The way to get it to work in the current implementation is to pass the query parameters in an array syntax. (I have never actually seen this in use before, but it may be used in the wild somewhere.)

```
foo[]=1&foo[]=2&foo[]=3
currently returns 
{ 'foo' : [ '1', '2', '3' ] }
```

This patch addresses both of these cases. Also added unit test.
