### PR TITLE
Added support for handling java objects to jsDump.

### DIFF
--- a/modules/test.js
+++ b/modules/test.js
@@ -61,8 +61,10 @@ function jsDump(value, lvl) {
                 buf.push(jsDump.indent(lvl + 1) + '"' + propName + '": ' + jsDump(value[propName], lvl + 1));
             }
             return ["{", buf.join(",\n"), jsDump.indent(lvl) + "}"].join("\n");
+        case "java":
+            return '<java:' + value.class.name + '>';
     }
-};
+}
 jsDump.indent = function(lvl) {
     return strings.repeat(" ", 4 * lvl);
 };
@@ -96,9 +98,11 @@ function getType(obj) {
         return "regexp";
     } else if (obj instanceof Function) {
         return "function";
+    } else if (obj instanceof java.lang.Object) {
+        return "java";
     }
     return "object";
-};
+}
 
 /**
  * Creates a stack trace and parses it for display.


### PR DESCRIPTION
jsDump() usually chokes with an OOM exception when a Java object is used in an assertion. This is caused because of the recursive nature of many Java objects. I added some code to print out the classname of a java object when it is passed to jsDump.

Where this comes up for me a lot is when I check for the presence of a Java object using:

```
assert.isNotNull(someVarThatHappensToBeAJavaObject)
```
