### PR TITLE
Fixed issue when startsWith() and endsWith() are passed a null value.

### DIFF
--- a/modules/ringo/utils/strings.js
+++ b/modules/ringo/utils/strings.js
@@ -355,6 +355,7 @@ function repeat(string, num) {
  *            of the string, false otherwise
  */
 function startsWith(string, substring) {
+    if (!string) return false;
     return string.indexOf(substring) == 0;
 }
 
@@ -366,6 +367,7 @@ function startsWith(string, substring) {
  *            the string, false otherwise
  */
 function endsWith(string, substring) {
+    if (!string) return false;
     var diff = string.length - substring.length;
     return diff > -1 && string.lastIndexOf(substring) == diff;
 }


### PR DESCRIPTION
This problem actually showed up in some stick code because contentType was not checked for null before using strings.startsWith(). I thought it would be better to fix the code in the strings.js module.
