### PR TITLE
Fix for clone with null and undefined values

### DIFF
--- a/modules/ringo/utils/objects.js
+++ b/modules/ringo/utils/objects.js
@@ -36,10 +36,10 @@ function clone(object, cloned, recursive) {
     var value;
     for (var propName in object) {
         value = object[propName];
-	
-	if (!value) {
-	    cloned[propName] = value;
-	} else if (recursive && (value.constructor == Object || value.constructor == Array)) {
+        
+        if (!value) {
+            cloned[propName] = value;
+        } else if (recursive && (value.constructor == Object || value.constructor == Array)) {
             cloned[propName] = clone(value, new value.constructor(), recursive);
         } else {
             cloned[propName] = value;


### PR DESCRIPTION
Added check for null and undefined values in the clone() function in objects.js. Was causing errors. 
