### PR TITLE
Use existing repositoryFromClasspath method.

### DIFF
--- a/src/org/ringojs/engine/RingoConfiguration.java
+++ b/src/org/ringojs/engine/RingoConfiguration.java
@@ -189,19 +189,10 @@ public class RingoConfiguration {
             }
         }
         // Try to resolve path as classpath resource
-        URL url = RingoConfiguration.class.getResource("/" + path);
-        if (url != null) {
-            String protocol = url.getProtocol();
-            if (("jar".equals(protocol) || "zip".equals(protocol))) {
-                Repository jar = toZipRepository(url);
-                if (jar != null) {
-                    repository = jar.getChildRepository(path);
-                    if (repository.exists()) {
-                        repository.setRoot();
-                        return repository;
-                    }
-                }
-            }
+        repository = repositoryFromClasspath(path);
+        if (repository != null && repository.exists()) {
+            repository.setRoot();
+            return repository;
         }
         return null;
     }


### PR DESCRIPTION
In some servlet containers (e.g. Glassfish), the ringo.jar is extracted and the result of `RingoConfiguration.class.getResource("/modules")` is a URL with the file protocol.  The existing `resolveRepository` method only accounts for jar and zip protocols.  The existing `repositoryFromClasspath` method accounts for file based URLs.

With this change, Ringo works for me on Glassfish and Tomcat using modules bundled in ringo.jar.
