### PR TITLE
Add Debian package build dependencies and build instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Building RingoJS
 ----------------
 
 Ringo requires a recent version of [Java]. It uses Apache [Ant] as build tool
-and [Ivy] for managing dependencies.
+and [Ivy] for managing dependencies. To build debian package, make sure you have following package build-essential debhelper installed .(apt-get install build-essential debhelper)
 
 [Java]: http://www.oracle.com/technetwork/java/javase/downloads/index.html
 [Ant]: http://ant.apache.org/
@@ -43,6 +43,10 @@ Then run the `jar` task to compile the code and build the jar file:
 Run the `docs` task to build the documentation:
 
     ant docs
+
+Run the `dpkg` task to build the debian package
+
+    ant dpkg
 
 Running RingoJS
 ---------------


### PR DESCRIPTION
The original readme doesn't have build instruction for debian package and no dependencies mentioned either.  
You are welcome to modify it to follow your style, but thought this instruction is useful for people who wants to build debian package.
