### PR TITLE
Don't be blind, print undefined !

### DIFF
--- a/modules/ringo/shell.js
+++ b/modules/ringo/shell.js
@@ -94,7 +94,8 @@ var styles = {
     'null': term.BOLD,
     'date': term.MAGENTA,
     'java': term.MAGENTA,
-    'custom': term.RED
+    'custom': term.RED,
+    'undefined': term.ONBLACK
 }
 
 function convert(value, nesting, visited) {
@@ -171,7 +172,7 @@ function convert(value, nesting, visited) {
             }
             break;
         case 'undefined':
-            retval = {};
+            retval.type = retval.string = "undefined";
             break;
         default:
             retval.string = String(value);
@@ -181,11 +182,9 @@ function convert(value, nesting, visited) {
 }
 
 function printResult(value, writer) {
-    if (typeof value !== "undefined") {
-        writer = writer || term;
-        printValue(convert(value, 0, []), writer, 0);
-        writer.writeln();
-    }
+    writer = writer || term;
+    printValue(convert(value, 0, []), writer, 0);
+    writer.writeln();
 }
 
 function printValue(value, writer, nesting) {


### PR DESCRIPTION
afaik, all modern javascript consoles prints `undefined` with the exception of rhino and spidermonkey-bin. As ringo is rhino based, I'd understand if this pull request is rejected.

Anyway, when you're used to other javascript vm's consoles, the lack of `undefined` gives a weird feeling (like you're blind of something). But maybe it's just me :-)
