### PR TITLE
httpclient to test response body contentBytes before apply decodeToString to prevent exception

### DIFF
--- a/modules/ringo/httpclient.js
+++ b/modules/ringo/httpclient.js
@@ -312,7 +312,7 @@ var Exchange = function(url, options, callbacks) {
                 if (responseContent !== undefined) {
                     return responseContent;
                 }
-                return responseContent = this.contentBytes.decodeToString(this.encoding);
+                return responseContent = this.contentBytes==null?null:this.contentBytes.decodeToString(this.encoding);
             }, "enumerable": true
         },
         /**


### PR DESCRIPTION
prevent from throw an error when an empty http body was returned.  also this is an effort to allow http test to pass issue 212 on github
