### PR TITLE
assert.throws() no longer accepts String as expectedError

### DIFF
--- a/modules/assert.js
+++ b/modules/assert.js
@@ -417,6 +417,8 @@ function isExpectedException(actual, expected) {
 
     if (Object.prototype.toString.call(expected) == '[object RegExp]') {
         return expected.test(actual);
+    } else if (actual === null && actual === expected) {
+        return true;
     } else if (actual instanceof expected ||
                     actual.rhinoException instanceof expected ||
                     actual.javaException instanceof expected) {
@@ -444,7 +446,7 @@ function throws(func, expectedError, message) {
     }
     if (typeof expectedError === 'string') {
       message = expectedError;
-      expectedError = null;
+      expectedError = undefined;
     }
     var actualError;
     // the actualError thrown could be `undefined`

--- a/test/assert.js
+++ b/test/assert.js
@@ -232,7 +232,7 @@ exports.testThrows = function() {
     // throw undefined (yes, you can do that...)
     assert.throws(function() {
         throw undefined;
-    }, undefined);
+    });
     // throw Error instance
     assert.throws(function() {
         throw new Error("a message");
@@ -244,7 +244,7 @@ exports.testThrows = function() {
     // throw string
     assert.throws(function() {
         throw "my message";
-    }, "my message");
+    }, /my message/);
     // throw java exception
     assert.throws(function() {
         var x = new java.util.Vector(0);

--- a/test/assert.js
+++ b/test/assert.js
@@ -233,6 +233,18 @@ exports.testThrows = function() {
     assert.throws(function() {
         throw undefined;
     });
+    assert.throws(function() {
+        throw null;
+    }, null);
+    var threw = false;
+    try {
+        assert.throws(function() {
+            throw 'notnull'
+        }, null);
+    } catch (e) {
+        threw = true;
+    }
+    assert.ok(threw, 'throws is accepting wrong exception');
     // throw Error instance
     assert.throws(function() {
         throw new Error("a message");

--- a/test/assert_commonjs.js
+++ b/test/assert_commonjs.js
@@ -154,19 +154,51 @@ exports['test throw AssertionError'] = function () {
     //if not passing an error, catch all.
     assert['throws'](makeBlock(thrower, TypeError));
     //when passing a type, only catch errors of the appropriate type
-    // NOTE: this fails, the spec doesn't say anything only catching expected errors
     var threw = false;
     try {
         assert['throws'](makeBlock(thrower, TypeError), assert.AssertionError);
     } catch (e) {
         threw = true;
-        /* -- Temporarily disabled until this issue is resolved. --
-        assert.ok(e instanceof TypeError, 'type');
-        */
+        // The spec says nothing about re-throwing the original exception;
+        // We throw an AssertionError if the expected does not match the actual
+        //assert.ok(e instanceof TypeError, 'type');
     }
     assert.ok(threw, 'assert.throws with an explicit error is eating extra errors');
     threw = false;
 
+    // doesNotThrow should pass through all errors
+    try {
+      assert.doesNotThrow(makeBlock(thrower, TypeError), a.AssertionError);
+    } catch (e) {
+      threw = true;
+      assert.ok(e instanceof TypeError);
+    }
+    assert.equal(true, threw,
+                 'a.doesNotThrow with an explicit error is eating extra errors');
+
+    // make sure that validating using constructor really works
+    threw = false;
+    try {
+      assert.throws(
+          function() {
+            throw ({});
+          },
+          Array
+      );
+    } catch (e) {
+      threw = true;
+    }
+    assert.ok(threw, 'wrong constructor validation');
+
+    // use a RegExp to validate error message
+    assert.throws(makeBlock(thrower, TypeError), /test/);
+
+    // use a fn to validate error object
+    assert.throws(makeBlock(thrower, TypeError), function(err) {
+      if ((err instanceof TypeError) && /test/.test(err)) {
+        return true;
+      }
+    });
 };
 
 if (module == require.main)

--- a/test/assert_commonjs.js
+++ b/test/assert_commonjs.js
@@ -166,16 +166,6 @@ exports['test throw AssertionError'] = function () {
     assert.ok(threw, 'assert.throws with an explicit error is eating extra errors');
     threw = false;
 
-    // doesNotThrow should pass through all errors
-    try {
-      assert.doesNotThrow(makeBlock(thrower, TypeError), a.AssertionError);
-    } catch (e) {
-      threw = true;
-      assert.ok(e instanceof TypeError);
-    }
-    assert.equal(true, threw,
-                 'a.doesNotThrow with an explicit error is eating extra errors');
-
     // make sure that validating using constructor really works
     threw = false;
     try {


### PR DESCRIPTION
I just wanted to add the optional `message` argument to `assert.throws` but the commonjs spec
is broken in that regard: with `throws(fooFunction, 'foo')` it is unclear
whether `foo` is the expected error to be thrown or the optional message arg since
both could be Strings.

Ringo now only allows `Function` or `RegExp` as type of expectedError.
This is in line with qunit and nodejs and it allows us to finally have that 
message argument.