### PR TITLE
#215 fix, align timezone indicator from - to + when in GMT

### DIFF
--- a/modules/ringo/utils/dates.js
+++ b/modules/ringo/utils/dates.js
@@ -552,7 +552,7 @@ function toISOString(date, withTime, withTimeZone, withSeconds, withMilliseconds
         inMinutes = Math.abs(offset) - (inHours * 60);
 
         // Write the time zone offset in hours
-        if (offset < 0) {
+        if (offset <= 0) {
             str += "+";
         } else {
             str += "-";


### PR DESCRIPTION
in order to fix issue #215

...ring when in GMT timezone(Expected "2013-02-21T19:09:24+00:00", got "2013-02-21T19:09:24-00:00") with + sign to indicate timezone
