### PR TITLE
Connection timeout for HttpClient

### DIFF
--- a/test/ringo/httpclient_test.js
+++ b/test/ringo/httpclient_test.js
@@ -106,6 +106,32 @@ exports.testBasic = function() {
     assert.strictEqual(myData, text);
 };
 
+exports.testConnectTimeout = function() {
+    var text = "<h1>This is the Response Text</h1>";
+
+    getResponse = function(req) {
+        return response.html(text);
+    };
+
+    var errorCalled, myData;
+    var exchange = request({
+        url: 'http://nosuchurl.visualxs.com',
+        connectTimeout: 5000,
+        success: function(data, status, contentType, exchange) {
+            assert.fail( 'Should of timed out before connection' );
+        },
+        error: function(message, status, exchange) {
+            assert.equal( message, 'timeout' );
+            assert.equal( status, 500 );
+        },
+        complete: function(data, status, contentType, exchange) {
+            assert.equal( data, 'timeout' );
+            assert.equal( status, 500 );
+            assert.isUndefined( contentType );
+        }
+    });
+};
+
 /**
  * test user info in url
  */


### PR DESCRIPTION
The httpclient module did not have support for read/connect timeouts. This pull request adds that capability.
