### PR TITLE
Handling javaexceptions and avoiding obscure exceptions like "unable to get property xxx from null" when trying to access exchange.status

### DIFF
--- a/modules/ringo/httpclient.js
+++ b/modules/ringo/httpclient.js
@@ -298,7 +298,7 @@ var readResponse = function(connection) {
  */
 var Exchange = function(url, options, callbacks) {
     var reqData = options.data;
-    var connection = null;
+    var connection;
     var responseContent;
     var responseContentBytes;
     var isDone = false;
@@ -413,21 +413,27 @@ var Exchange = function(url, options, callbacks) {
             var content = (options.binary === true) ? this.contentBytes : this.content;
             callbacks.success(content, this.status, this.contentType, this);
         }
-    } catch (e if e.javaException instanceof java.net.SocketTimeoutException) {
-        isException = 'timeout';
-        if (typeof(callbacks.error) === "function") {
-            callbacks.error("timeout", 500, this);
-        }
     } catch (e) {
+        var message;
+        if (e.javaException != undefined) {
+            this.exception = e.javaException;
+            message = e.javaException.toString();
+            try {
+                connection.disconnect();
+                connection = undefined;
+            } catch(e) {}
+        } else {
+            message = this.message;
+        }
         if (typeof(callbacks.error) === "function") {
-            callbacks.error(this.message, this.status, this);
+            callbacks.error(message, this.status, this);
         }
     } finally {
         isDone = true;
         try {
             if (typeof(callbacks.complete) === "function") {
                 if (isException) {
-                    callbacks.complete(isException, 500, undefined, this);
+                    callbacks.complete(isException, this.status, undefined, this);
                 } else {
                     var content = (options.binary === true) ? this.contentBytes : this.content;
                     callbacks.complete(content, this.status, this.contentType, this);
@@ -449,7 +455,7 @@ Object.defineProperties(Exchange.prototype, {
      */
     "url": {
         "get": function() {
-            return this.connection.getURL();
+            return this.connection ? this.connection.getURL() : undefined;
         }, "enumerable": true
     },
     /**
@@ -459,7 +465,7 @@ Object.defineProperties(Exchange.prototype, {
      */
     "status": {
         "get": function() {
-            return this.connection.getResponseCode();
+            return this.connection ? this.connection.getResponseCode() : 0;
         }, "enumerable": true
     },
     /**
@@ -469,7 +475,7 @@ Object.defineProperties(Exchange.prototype, {
      */
     "message": {
         "get": function() {
-            return this.connection.getResponseMessage();
+            return this.connection ? this.connection.getResponseMessage() : undefined;
         }, "enumerable": true
     },
     /**
@@ -478,7 +484,7 @@ Object.defineProperties(Exchange.prototype, {
      */
     "headers": {
         "get": function() {
-            return new ScriptableMap(this.connection.getHeaderFields());
+            return this.connection ? new ScriptableMap(this.connection.getHeaderFields()) : undefined;
         }, enumerable: true
     },
     /**
@@ -487,6 +493,9 @@ Object.defineProperties(Exchange.prototype, {
      */
     "cookies": {
         "get": function() {
+            if (!this.connection) {
+                return undefined;
+            }
             var cookies = {};
             var cookieHeaders = this.connection.getHeaderField("Set-Cookie");
             if (cookieHeaders !== null) {
@@ -506,7 +515,7 @@ Object.defineProperties(Exchange.prototype, {
      */
     "encoding": {
         "get": function() {
-            return getMimeParameter(this.contentType, "charset") || "utf-8";
+            return this.connection ? (getMimeParameter(this.contentType, "charset") || "utf-8") : undefined;
         }, "enumerable": true
     },
     /**
@@ -516,7 +525,7 @@ Object.defineProperties(Exchange.prototype, {
      */
     "contentType": {
         "get": function() {
-            return this.connection.getContentType();
+            return this.connection ? this.connection.getContentType() : undefined;
         }, "enumerable": true
     },
     /**
@@ -526,7 +535,7 @@ Object.defineProperties(Exchange.prototype, {
      */
     "contentLength": {
         "get": function() {
-            return this.connection.getContentLength();
+            return this.connection ? this.connection.getContentLength() : undefined;
         }, "enumerable": true
     }
 });

--- a/test/ringo/httpclient_test.js
+++ b/test/ringo/httpclient_test.js
@@ -559,6 +559,42 @@ exports.testPostMultipart = function() {
     assert.deepEqual(received.image.value.toArray(), imageByteArray.toArray());
 };
 
+exports.testProxiedRequest = function() {
+    var text = "<h1>This is the Response Text</h1>";
+
+    getResponse = function(req) {
+        return response.html(text);
+    };
+
+    var errorCalled, myData;
+    var exchange = request({
+        url: "http://idontexistandifigetcalledwithoutproxyshouldraiseerror.com",
+        proxy: [host, ":", port].join(""),
+        success: function(data, status, contentType, exchange) {
+            myData = data;
+        },
+        error: function() {
+            errorCalled = true;
+        }
+    });
+    assert.isUndefined(errorCalled);
+    assert.strictEqual(myData, text);
+
+    errorCalled = myData = undefined;
+    var exchange = request({
+        url: "http://idontexistandifigetcalledwithoutproxyshouldraiseerror.com",
+        proxy: {"host": host, "port": port},
+        success: function(data, status, contentType, exchange) {
+            myData = data;
+        },
+        error: function() {
+            errorCalled = true;
+        }
+    });
+    assert.isUndefined(errorCalled);
+    assert.strictEqual(myData, text);
+};
+
 // start the test runner if we're called directly from command line
 if (require.main == module.id) {
     var {run} = require("test");

--- a/test/ringo/httpclient_test.js
+++ b/test/ringo/httpclient_test.js
@@ -595,6 +595,47 @@ exports.testProxiedRequest = function() {
     assert.strictEqual(myData, text);
 };
 
+exports.testMalformedUrl = function() {
+    var errorCalled, completeCalled, myData;
+    var exchange = request({
+        url: "malformedurl",
+        success: function(data, status, contentType, exchange) {
+            myData = data;
+        },
+        error: function() {
+            errorCalled = true;
+        },
+        complete: function() {
+            completeCalled=true;
+        }
+    });
+    assert.isNotNull(exchange.exception);
+    assert.isTrue(errorCalled);
+    assert.isTrue(completeCalled);
+    assert.equal(exchange.status, 0);
+};
+
+exports.testUnknownHost = function() {
+    var errorCalled, completeCalled, myData;
+    var exchange = request({
+        url: "http://nohostwiththisname.uhrorg",
+        success: function(data, status, contentType, exchange) {
+            myData = data;
+        },
+        error: function() {
+            errorCalled = true;
+        },
+        complete: function() {
+            completeCalled=true;
+        }
+    });
+    assert.isNotNull(exchange.exception);
+    assert.isTrue(errorCalled);
+    assert.isTrue(completeCalled);
+    assert.equal(exchange.status, 0);
+};
+
+
 // start the test runner if we're called directly from command line
 if (require.main == module.id) {
     var {run} = require("test");


### PR DESCRIPTION
Exception-handling was fairly broken. Requests with malformed url's or unknown hosts returned an empty exchange-object which had no connection-property.
This caused exchange.status - which is a getter on exchange.connection.getResponseCode() - to throw an obscuring exception (Unable to get property from null).

A request which would result in an java-exception (MalformedUrl, UnknownHost, SocketTimeoutException...) will now return an exchange-object which has an additional property "exception" holding the java-exception.
The exchange-object's status-property will return 0 (zero) which is an invalid HTTP-Response and therefore indicating that something went wrong. This is derived from jquery which also returns 0 in such cases.
This aproach has been choosen to not break existing code - even if existing code would have failed when trying to access exchange.status or in some cases just by providing an error-/success-/complete-callback which also accessed exchange.status.

Please let me know if we want to merge this pull-request.