### PR TITLE
Load ./packages by default, fixes #282

### DIFF
--- a/src/org/ringojs/engine/RingoConfig.java
+++ b/src/org/ringojs/engine/RingoConfig.java
@@ -119,9 +119,17 @@ public class RingoConfig {
         }
 
         if (userModules != null) {
-            for (String pathElem : userModules) {
-                String path = pathElem.trim();
-                addModuleRepository(resolveRepository(path, false));
+            if (userModules.length > 0) {
+                for (String pathElem : userModules) {
+                    String path = pathElem.trim();
+                    addModuleRepository(resolveRepository(path, false));
+                }
+            } else {
+                // load ./packages by default as module path
+                File candidatePath = new File(System.getProperty("user.dir"), "packages");
+                if (candidatePath.isDirectory()) {
+                    addModuleRepository(resolveRepository(candidatePath.toString(), false));
+                }
             }
         }
 


### PR DESCRIPTION
Instead of manually adding ./packages all the time, this fix add it by default if no user modules are specified.