### PR TITLE
dates.parse() should always return NaN on invalid dates

### DIFF
--- a/modules/ringo/utils/dates.js
+++ b/modules/ringo/utils/dates.js
@@ -20,32 +20,35 @@
  */
 
 var strings = require('ringo/utils/strings');
- export( "format",
-        "checkDate",
-        "add",
-        "isLeapYear",
-        "before",
-        "after",
-        "compare",
-        "firstDayOfWeek",
-        "secondOfDay",
-        "dayOfYear",
-        "weekOfMonth",
-        "weekOfYear",
-        "quarterInYear",
-        "quarterInFiscalYear",
-        "yearInCentury",
-        "daysInMonth",
-        "daysInYear",
-        "daysInFebruary",
-        "diff",
-        "overlapping",
-        "inPeriod",
-        "resetTime",
-        "resetDate",
-        "toISOString",
-        "fromUTCDate",
-        "parse" );
+
+export(
+    "format",
+    "checkDate",
+    "add",
+    "isLeapYear",
+    "before",
+    "after",
+    "compare",
+    "firstDayOfWeek",
+    "secondOfDay",
+    "dayOfYear",
+    "weekOfMonth",
+    "weekOfYear",
+    "quarterInYear",
+    "quarterInFiscalYear",
+    "yearInCentury",
+    "daysInMonth",
+    "daysInYear",
+    "daysInFebruary",
+    "diff",
+    "overlapping",
+    "inPeriod",
+    "resetTime",
+    "resetDate",
+    "toISOString",
+    "fromUTCDate",
+    "parse"
+);
 
 /**
  * Format a Date to a string.
@@ -627,7 +630,7 @@ function parse(str) {
 
             // Check if the given date is valid
             if (date.getUTCMonth() != month || date.getUTCDate() != day) {
-                return new Date("invalid");
+                return NaN;
             }
 
             // optional time
@@ -656,7 +659,7 @@ function parse(str) {
                     date.setUTCHours(hours, minutes, seconds, milliseconds);
                     if (date.getUTCHours() != hours || date.getUTCMinutes() != minutes || date.getUTCSeconds() != seconds) {
                         if(!validTimeValues(hours, minutes, seconds, milliseconds)) {
-                            return new Date("invalid");
+                            return NaN;
                         }
                     }
 
@@ -668,7 +671,7 @@ function parse(str) {
 
                         // check maximal timezone offset (24 hours)
                         if (Math.abs(offset) >= 86400000) {
-                            return new Date("invalid");
+                            return NaN;
                         }
                         date = new Date(date.getTime() + offset);
                     }
@@ -676,13 +679,13 @@ function parse(str) {
                     date.setHours(hours, minutes, seconds, milliseconds);
                     if (date.getHours() != hours || date.getMinutes() != minutes || date.getSeconds() != seconds) {
                         if(!validTimeValues(hours, minutes, seconds, milliseconds)) {
-                            return new Date("invalid");
+                            return NaN;
                         }
                     }
                 }
             }
         } else {
-            date = new Date("invalid");
+            date = NaN;
         }
     }
     return date;

--- a/modules/ringo/utils/dates.js
+++ b/modules/ringo/utils/dates.js
@@ -606,11 +606,12 @@ function fromUTCDate(year, month, date, hour, minute, second) {
  * For details on the string format, see http://tools.ietf.org/html/rfc3339.  Examples
  * include "2010", "2010-08-06", "2010-08-06T22:04:30Z", "2010-08-06T16:04:30-06".
  *
- * @param {String} str The date string.  This follows the format specified for timestamps
+ * @param {String} str The date string. This follows the format specified for timestamps
  *        on the internet described in RFC 3339.
- * @returns {Date} a date representing the given string
+ * @returns {Date|NaN} a date representing the given string, or <code>NaN</code> for unrecognizable strings
  * @see http://tools.ietf.org/html/rfc3339
  * @see http://www.w3.org/TR/NOTE-datetime
+ * @see https://es5.github.io/#x15.9.4.2
  */
 function parse(str) {
     var date;

--- a/test/ringo/utils/dates_test.js
+++ b/test/ringo/utils/dates_test.js
@@ -625,15 +625,23 @@ exports.testParse = function() {
     assert.strictEqual((dates.parse("2010-10-26T00:00:00.00Z")).getTime(), 1288051200000);
     assert.strictEqual((dates.parse("2010-10-26T00:00:00.000Z")).getTime(), 1288051200000);
 
-    // NaN
+    // NaN and not instance of Date
     assert.isNaN(dates.parse("asdf"));
+    assert.isFalse(dates.parse("asdf") instanceof Date, "parse should return NaN and not an invalid Date");
     assert.isNaN(dates.parse("2010-"));
+    assert.isFalse(dates.parse("2010-") instanceof Date, "parse should return NaN and not an invalid Date");
     assert.isNaN(dates.parse("2010-99"));
+    assert.isFalse(dates.parse("2010-99") instanceof Date, "parse should return NaN and not an invalid Date");
     assert.isNaN(dates.parse("2010-01-99"));
+    assert.isFalse(dates.parse("2010-01-99") instanceof Date, "parse should return NaN and not an invalid Date");
     assert.isNaN(dates.parse("2010-01-01T24:59Z"));
+    assert.isFalse(dates.parse("2010-01-01T24:59Z") instanceof Date, "parse should return NaN and not an invalid Date");
     assert.isNaN(dates.parse("2010-01-01T25:00Z"));
+    assert.isFalse(dates.parse("2010-01-01T25:00Z") instanceof Date, "parse should return NaN and not an invalid Date");
     assert.isNaN(dates.parse("2010-01-01TT25:00Z"));
+    assert.isFalse(dates.parse("2010-01-01TT25:00Z") instanceof Date, "parse should return NaN and not an invalid Date");
     assert.isNaN(dates.parse("2010-01-01T23:00-25:00"));
+    assert.isFalse(dates.parse("2010-01-01T23:00-25:00") instanceof Date, "parse should return NaN and not an invalid Date");
 
     // Check for not NaN
     // FIXME no exact checks because of local time...


### PR DESCRIPTION
This makes `ringo/utils/dates#parse()` compliant to the native `Date.parse()`. Also see [Nashorn's implementation](http://hg.openjdk.java.net/nashorn/jdk9/nashorn/file/4e97628f17be/src/jdk/nashorn/internal/objects/NativeDate.java#l885)