### PR TITLE
Fix for issue #303 - Windows-Console and unicode characters

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -33,6 +33,6 @@
         <!-- junit -->
         <dependency org="junit" name="junit" rev="3.8.+"/>
         <!-- jline -->
-        <dependency org="jline" name="jline" rev="1.0"/>
+        <dependency org="jline" name="jline" rev="2.12.1"/>
     </dependencies>
 </ivy-module>

--- a/modules/ringo/term.js
+++ b/modules/ringo/term.js
@@ -30,7 +30,7 @@ var supportedTerminals = {
     'gnome-terminal': 1
 };
 
-var javaConsole = System.console();
+var javaConsole = System.console() || System.out;
 var enabled = env.TERM && env.TERM in supportedTerminals;
 
 exports.RESET =     "\u001B[0m";

--- a/modules/ringo/term.js
+++ b/modules/ringo/term.js
@@ -17,7 +17,6 @@
 
 var system = require('system');
 var {Stream, TextStream} = require('io');
-var {AnsiConsole} = org.fusesource.jansi;
 var System = java.lang.System;
 
 var env = system.env;
@@ -30,20 +29,9 @@ var supportedTerminals = {
     'xterm-256color': 1,
     'gnome-terminal': 1
 };
-var jansiInstalled = typeof AnsiConsole === "function";
-
-var enabled = (!javaConsole || javaConsole())
-        && ((env.TERM && env.TERM in supportedTerminals) || jansiInstalled);
-
-if (jansiInstalled) {
-    // Jansi wraps System.out and System.err so we need to
-    // reset stdout and stderr in the system module
-    AnsiConsole.systemInstall();
-    system.stdout = new TextStream(new Stream(System.out));
-    system.stderr = new TextStream(new Stream(System.err));
-}
 
 var javaConsole = System.console();
+var enabled = env.TERM && env.TERM in supportedTerminals;
 
 exports.RESET =     "\u001B[0m";
 exports.BOLD =      "\u001B[1m";

--- a/modules/ringo/term.js
+++ b/modules/ringo/term.js
@@ -105,7 +105,7 @@ var TermWriter = exports.TermWriter = function() {
             if (!_enabled) {
                 arg = arg.replace(cleaner, '');
             }
-            javaConsole.printf(arg);
+            javaConsole.printf("%s", arg);
             if (arg && !matcher.test(arg) && i < arguments.length - 1) {
                 javaConsole.printf(" ");
             }

--- a/src/org/ringojs/tools/RingoShell.java
+++ b/src/org/ringojs/tools/RingoShell.java
@@ -16,9 +16,9 @@
 
 package org.ringojs.tools;
 
-import jline.Completor;
-import jline.ConsoleReader;
-import jline.History;
+import jline.console.completer.Completer;
+import jline.console.ConsoleReader;
+import jline.console.history.FileHistory;
 import org.ringojs.engine.ModuleScope;
 import org.ringojs.engine.ReloadableScript;
 import org.ringojs.engine.RhinoEngine;
@@ -83,11 +83,11 @@ public class RingoShell {
         ConsoleReader reader = new ConsoleReader();
         reader.setBellEnabled(false);
         // reader.setDebug(new PrintWriter(new FileWriter("jline.debug")));
-        reader.addCompletor(new JSCompletor());
+        reader.addCompleter(new JSCompleter());
         if (history == null) {
             history = new File(System.getProperty("user.home"), ".ringo-history");
         }
-        reader.setHistory(new History(history));
+        reader.setHistory(new FileHistory(history));
         PrintStream out = System.out;
         int lineno = 0;
         repl: while (true) {
@@ -215,7 +215,7 @@ public class RingoShell {
         t.start();
     }
 
-    class JSCompletor implements Completor {
+    class JSCompleter implements Completer {
 
         Pattern variables = Pattern.compile(
                 "(^|\\s|[^\\w\\.'\"])([\\w\\.]+)$");


### PR DESCRIPTION
This PR depends on #268 since it uses System.console(), which requires at least Java 6.