### PR TITLE
Drops ringo/httpclient callbacks

### DIFF
--- a/modules/ringo/httpclient.js
+++ b/modules/ringo/httpclient.js
@@ -26,6 +26,7 @@ var objects = require("ringo/utils/objects");
 var base64 = require("ringo/base64");
 var {Buffer} = require("ringo/buffer");
 var {Random} = java.util;
+var log = require("ringo/logging").getLogger(module.id);
 
 export("request", "get", "post", "put", "del", "TextPart", "BinaryPart");
 
@@ -477,6 +478,11 @@ Object.defineProperties(Exchange.prototype, {
  * @see #del
  */
 var request = function(options) {
+    if (options.beforeSend != null || options.complete != null ||
+        options.success != null || options.error != null) {
+        log.warn("ringo/httpclient does not support callbacks anymore!");
+    }
+
     var opts = prepareOptions(options);
     return new Exchange(opts.url, {
         "method": opts.method,

--- a/modules/ringo/httpclient.js
+++ b/modules/ringo/httpclient.js
@@ -57,63 +57,6 @@ var prepareOptions = function(options) {
 };
 
 /**
- * Of the 4 arguments to get/post all but the first (url) are optional.
- * This fn puts the right arguments - depending on their type - into the options object
- * which can be used to call request().
- * @param {Array} Arguments Array
- * @returns Object holding attributes for call to request()
- * @type Object<url, data, success, error>
- */
-var extractOptionalArguments = function(args) {
-
-    var types = [];
-    for each (var arg in args) {
-        types.push(typeof(arg));
-    }
-
-    if (types[0] != 'string') {
-        throw new Error('first argument (url) must be string');
-    }
-
-    if (args.length == 1) {
-        return {
-            url: args[0]
-        };
-
-    } else if (args.length == 2) {
-        if (types[1] == 'function') {
-            return {
-                url: args[0],
-                success: args[1]
-            };
-        } else {
-            return {
-                url: args[0],
-                data: args[1]
-            };
-        }
-        throw new Error('two argument form must be (url, success) or (url, data)');
-    } else if (args.length == 3) {
-        if (types[1] == 'function' && types[2] == 'function') {
-            return {
-                url: args[0],
-                success: args[1],
-                error: args[2]
-            };
-        } else if (types[1] == 'object' && types[2] == 'function') {
-            return {
-                url: args[0],
-                data: args[1],
-                success: args[2]
-            };
-        } else {
-            throw new Error('three argument form must be (url, success, error) or (url, data, success)');
-        }
-    }
-    throw new Error('unknown arguments');
-};
-
-/**
  * A wrapper around java.net.HttpCookie
  * @param {java.net.HttpCookie} httpCookie The HttpCookie instance to wrap
  * @returns {Cookie} A newly created Cookie instance
@@ -271,6 +214,7 @@ var readResponse = function(connection) {
     try {
         inStream = connection[(status >= 200 && status < 400) ?
                 "getInputStream" : "getErrorStream"]();
+
         var encoding = connection.getContentEncoding();
         if (encoding != null) {
             if (encoding === "gzip") {
@@ -292,18 +236,15 @@ var readResponse = function(connection) {
  * @name Exchange
  * @param {String} url The URL
  * @param {Object} options The options
- * @param {Object} callbacks An object containing success, error and complete
- * callback methods
  * @returns {Exchange} A newly constructed Exchange instance
  * @constructor
  */
-var Exchange = function(url, options, callbacks) {
+var Exchange = function(url, options) {
     var reqData = options.data;
     var connection = null;
     var responseContent;
     var responseContentBytes;
-    var isDone = false;
-    var isException;
+    var thrownException;
 
     Object.defineProperties(this, {
         /**
@@ -314,15 +255,6 @@ var Exchange = function(url, options, callbacks) {
             "get": function() {
                 return connection;
             }, "enumerable": true
-        },
-        /**
-         * True if the request has completed, false otherwise.
-         * @name Exchange.prototype.done
-         */
-        "done": {
-            "get": function() {
-                return isDone;
-            }, enumerable: true
         },
         /**
          * The response body as String.
@@ -393,9 +325,6 @@ var Exchange = function(url, options, callbacks) {
         for (let key in options.headers) {
             connection.setRequestProperty(key, options.headers[key]);
         }
-        if (typeof(callbacks.beforeSend) === "function") {
-            callbacks.beforeSend(this);
-        }
 
         if (options.method === "POST" || options.method === "PUT") {
             connection.setDoOutput(true);
@@ -407,36 +336,8 @@ var Exchange = function(url, options, callbacks) {
             }
         }
         responseContentBytes = readResponse(connection);
-        if (this.status > 300) {
-            throw new Error(this.status);
-        }
-        if (typeof(callbacks.success) === "function") {
-            var content = (options.binary === true) ? this.contentBytes : this.content;
-            callbacks.success(content, this.status, this.contentType, this);
-        }
-    } catch (e if e.javaException instanceof java.net.SocketTimeoutException) {
-        isException = 'timeout';
-        if (typeof(callbacks.error) === "function") {
-            callbacks.error("timeout", 500, this);
-        }
-    } catch (e) {
-        if (typeof(callbacks.error) === "function") {
-            callbacks.error(this.message, this.status, this);
-        }
     } finally {
-        isDone = true;
-        try {
-            if (typeof(callbacks.complete) === "function") {
-                if (isException) {
-                    callbacks.complete(isException, 500, undefined, this);
-                } else {
-                    var content = (options.binary === true) ? this.contentBytes : this.content;
-                    callbacks.complete(content, this.status, this.contentType, this);
-                }
-            }
-        } finally {
-            connection && connection.disconnect();
-        }
+        connection && connection.disconnect();
     }
 
     return this;
@@ -568,27 +469,6 @@ Object.defineProperties(Exchange.prototype, {
  *     URLConnection. A timeout of zero is interpreted as an infinite timeout.;
  *     default: 60000 ms (or until impl decides its time)
  *
- *  #### Callbacks
- *
- *  The `options` object may also contain the following callback functions:
- *
- *  - `complete`: called when the request is completed
- *  - `success`: called when the request is completed successfully
- *  - `error`: called when the request is completed with an error
- *  - `beforeSend`: called with the Exchange object as argument before the request is sent
- *
- *  The following arguments are passed to the `complete`, `success` and `part` callbacks:
- *  1. `content`: the content as String or ByteString
- *  2. `status`: the HTTP status code
- *  3. `contentType`: the content type
- *  4. `exchange`: the exchange object
- *
- *  The following arguments are passed to the `error` callback:
- *  1. `message`: the error message. This is either the message from an exception thrown
- *     during request processing or an HTTP error message
- *  2. `status`: the HTTP status code. This is `0` if no response was received
- *  3. `exchange`: the exchange object
- *
  * @param {Object} options
  * @returns {Exchange} exchange object
  * @see #get
@@ -610,11 +490,6 @@ var request = function(options) {
         "readTimeout": opts.readTimeout,
         "binary": opts.binary,
         "proxy": opts.proxy
-    }, {
-        "beforeSend": opts.beforeSend,
-        "success": opts.success,
-        "complete": opts.complete,
-        "error": opts.error
     });
 };
 
@@ -623,22 +498,14 @@ var request = function(options) {
  * @param {String} method The request method
  * @param {String} url The URL
  * @param {String|Object|Stream|Binary} data Optional data to send to the server
- * @param {Function} success Optional success callback
- * @param {Function} error Optional error callback
  * @returns An options object
- * @type Object<method, url, data, success, error>
+ * @type Object<method, url, data>
  */
-var createOptions = function(method, url, data, success, error) {
-    var args = Array.prototype.slice.call(arguments, 1);
-    if (args.length < 4) {
-        var {url, data, success, error} = extractOptionalArguments(args);
-    }
+var createOptions = function(method, url, data) {
     return {
         method: method,
         url: url,
-        data: data,
-        success: success,
-        error: error
+        data: data
     };
 };
 
@@ -646,48 +513,40 @@ var createOptions = function(method, url, data, success, error) {
  * Executes a GET request.
  * @param {String} url The URL
  * @param {Object|String} data The data to append as GET parameters to the URL
- * @param {Function} success Optional success callback
- * @param {Function} error Optional error callback
  * @returns {Exchange} The Exchange instance representing the request and response
  */
-var get = function(url, data, success, error) {
-    return request(createOptions("GET", url, data, success, error));
+var get = function(url, data) {
+    return request(createOptions("GET", url, data));
 };
 
 /**
  * Executes a POST request.
  * @param {String} url The URL
  * @param {Object|String|Stream|Binary} data The data to send to the server
- * @param {Function} success Optional success callback
- * @param {Function} error Optional error callback
  * @returns {Exchange} The Exchange instance representing the request and response
  */
-var post = function(url, data, success, error) {
-    return request(createOptions("POST", url, data, success, error));
+var post = function(url, data) {
+    return request(createOptions("POST", url, data));
 };
 
 /**
  * Executes a DELETE request.
  * @param {String} url The URL
  * @param {Object|String} data The data to append as GET parameters to the URL
- * @param {Function} success Optional success callback
- * @param {Function} error Optional error callback
  * @returns {Exchange} The Exchange instance representing the request and response
  */
-var del = function(url, data, success, error) {
-    return request(createOptions("DELETE", url, data, success, error));
+var del = function(url, data) {
+    return request(createOptions("DELETE", url, data));
 };
 
 /**
  * Executes a PUT request.
  * @param {String} url The URL
  * @param {Object|String|Stream|Binary} data The data send to the server
- * @param {Function} success Optional success callback
- * @param {Function} error Optional error callback
  * @returns {Exchange} The Exchange instance representing the request and response
  */
-var put = function(url, data, success, error) {
-    return request(createOptions("PUT", url, data, success, error));
+var put = function(url, data) {
+    return request(createOptions("PUT", url, data));
 };
 
 /**

--- a/test/ringo/httpclient_test.js
+++ b/test/ringo/httpclient_test.js
@@ -517,6 +517,31 @@ exports.testTimeoutResponse_Issue267 = function() {
     }, java.net.SocketTimeoutException, "A timeout request should throw an exception!");
 };
 
+exports.testNoCallbacks = function() {
+    getResponse = function(req) {
+        return response.text("foo");
+    };
+
+    var anyCallbackCalled = false;
+    var exchange = request({
+        "url": baseUri,
+        "beforeSend": function() {
+            anyCallbackCalled = true;
+        },
+        "success": function() {
+            anyCallbackCalled = true;
+        },
+        "complete": function() {
+            anyCallbackCalled = true;
+        },
+        "error": function() {
+            anyCallbackCalled = true;
+        }
+    });
+
+    assert.isFalse(anyCallbackCalled, "Callback has been called!");
+    assert.strictEqual(exchange.status, 200);
+};
 
 // start the test runner if we're called directly from command line
 if (require.main == module.id) {

--- a/test/ringo/httpclient_test.js
+++ b/test/ringo/httpclient_test.js
@@ -498,6 +498,26 @@ exports.testIterateExchange_Issue287 = function() {
    assert.isUndefined(exchange.headers[null]);
 };
 
+exports.testTimeoutResponse_Issue267 = function() {
+    getResponse = function(req) {
+        var loops = 0;
+        var started = Date.now();
+        while (Date.now() - started < 100) {
+            loops++;
+        }
+        return response.text("did " + loops + " loops in " + (Date.now() - started) + " milliseconds.");
+    };
+
+    assert.throws(function() {
+        var exchange = request({
+            readTimeout: 1,
+            url: baseUri
+        });
+        assert.fail("This should not be reachable!");
+    }, java.net.SocketTimeoutException, "A timeout request should throw an exception!");
+};
+
+
 // start the test runner if we're called directly from command line
 if (require.main == module.id) {
     var {run} = require("test");

--- a/test/ringo/httpclient_test.js
+++ b/test/ringo/httpclient_test.js
@@ -53,37 +53,6 @@ exports.tearDown = function() {
 };
 
 /**
- * test that callbacks get called at all; all other
- * tests rely on that.
- */
-exports.testCallbacksGetCalled = function() {
-    getResponse = function(req) {
-      return response.html("");
-    };
-
-    var beforeSendCalled, successCalled, completeCalled, errorCalled;
-    request({
-        "url": baseUri,
-        "beforeSend": function(exchange) {
-            beforeSendCalled = true;
-        },
-        "success": function(data, status, contentType, exchange) {
-            successCalled = true;
-        },
-        "complete": function(data, status, contentType, exchange) {
-            completeCalled = true;
-        },
-        "error": function(message, status, exchange) {
-            errorCalled = true;
-        }
-    });
-    assert.isTrue(beforeSendCalled);
-    assert.isTrue(successCalled);
-    assert.isTrue(completeCalled);
-    assert.isUndefined(errorCalled);
-};
-
-/**
  * test basic get
  */
 exports.testBasic = function() {
@@ -95,16 +64,10 @@ exports.testBasic = function() {
 
     var errorCalled, myData;
     var exchange = request({
-        url: baseUri,
-        success: function(data, status, contentType, exchange) {
-            myData = data;
-        },
-        error: function() {
-            errorCalled = true;
-        }
+        url: baseUri
     });
-    assert.isUndefined(errorCalled);
-    assert.strictEqual(myData, text);
+
+    assert.strictEqual(exchange.content, text);
 };
 
 /**
@@ -144,25 +107,16 @@ exports.testUserInfo = function() {
  * test servlet on request env (this is not httpclient specific, but uses same setUp tearDown)
  */
 exports.testServlet = function() {
-
     var servlet;
     getResponse = function(req) {
         servlet = req.env.servlet;
         return response.html("servlet set");
     };
 
-    var errorCalled, myData;
     var exchange = request({
-        url: baseUri,
-        success: function(data, status, contentType, exchange) {
-            myData = data;
-        },
-        error: function() {
-            errorCalled = true;
-        }
+        url: baseUri
     });
-    assert.isUndefined(errorCalled);
-    assert.strictEqual(myData, "servlet set");
+    assert.strictEqual(exchange.content, "servlet set");
     assert.ok(servlet instanceof javax.servlet.http.HttpServlet, "servlet instance");
 };
 
@@ -234,12 +188,12 @@ exports.testParams = function() {
 };
 
 /**
- * Callbacks
+ * Status Codes
  */
-exports.testCallbacks = function() {
+exports.testStatusCodes = function() {
     getResponse = function(req) {
         if (req.pathInfo == '/notfound') {
-            return response.notFound('error');
+            return response.notFound().text("not found");
         } else if (req.pathInfo == '/success') {
             return response.json('success');
         } else if (req.pathInfo == '/redirect') {
@@ -252,57 +206,29 @@ exports.testCallbacks = function() {
             return response.html('redirect success');
         }
     };
-    var myStatus, successCalled, errorCalled, myMessage, myContentType, myData;
-    // success shouldn't get called
-    var getErrorExchange = request({
+
+    var exchange = request({
         url: baseUri + 'notfound',
-        method: 'GET',
-        complete: function(data, status, contentType, exchange) {
-            myStatus = status;
-        },
-        success: function() {
-            successCalled = true
-        },
-        error: function(message, status, exchange) {
-            myMessage = message;
-        }
+        method: 'GET'
     });
-    assert.isUndefined(successCalled);
-    assert.strictEqual(myStatus, 404);
-    assert.strictEqual(getErrorExchange.status, 404);
-    assert.strictEqual(myMessage, "Not Found");
+    assert.strictEqual(exchange.status, 404);
+    assert.strictEqual(exchange.content, "not found");
 
-    var getSuccessExchange = request({
+    exchange = request({
         url: baseUri + 'success',
-        method: 'GET',
-        complete: function(data, status, contentType, exchange) {
-            myStatus = status;
-        },
-        success: function(data, status, contentType, exchange) {
-            myContentType = contentType;
-        },
-        error: function() {
-            errorCalled = true;
-        }
+        method: 'GET'
     });
-    assert.strictEqual('application/json; charset=utf-8', myContentType);
-    assert.strictEqual(myStatus, 200);
-    assert.isUndefined(errorCalled);
+    assert.strictEqual('application/json; charset=utf-8', exchange.contentType);
+    assert.strictEqual(exchange.status, 200);
 
-    var getRedirectExchange = request({
+    exchange = request({
         url: baseUri + 'redirect',
         method: 'GET',
-        complete: function(data, status, contentType, exchange) {
-            myStatus = status;
-            myData = data;
-        },
-        error: function(message) {
-            errorCalled = true;
+        complete: function(hasError, exchange, message, ex) {
+            complete = hasError === true;
         }
     });
-    assert.strictEqual(myStatus, 200);
-    assert.strictEqual('redirect success', myData);
-    assert.isUndefined(errorCalled);
+    assert.strictEqual(exchange.status, 200);
 };
 
 /**
@@ -327,26 +253,15 @@ exports.testCookie = function() {
     };
 
     // receive cookie
-    var myStatus, myRequest, errorCalled;
-    request({
+    var exchange = request({
         url: baseUri,
         method: "GET",
         data: {
             "cookievalue": COOKIE_VALUE
-        },
-        complete: function(data, status, contentType, request) {
-            myStatus = status;
-        },
-        success: function(data, status, contentType, request) {
-            myRequest = request;
-        },
-        error: function() {
-            errorCalled = true;
         }
     });
-    assert.isUndefined(errorCalled);
-    assert.strictEqual(myStatus, 200);
-    var cookie = myRequest.cookies[COOKIE_NAME];
+    assert.strictEqual(exchange.status, 200);
+    var cookie = exchange.cookies[COOKIE_NAME];
     assert.strictEqual(cookie.value, COOKIE_VALUE);
     // FIXME: why is -1 necessary?
     assert.strictEqual(cookie.maxAge, (5 * 24 * 60 * 60) - 1);
@@ -394,24 +309,16 @@ exports.testStreamRequest = function() {
     var inputByteArray = new ByteArray(size);
     inputStream.read(inputByteArray, 0, size);
     var sendInputStream = resource.getInputStream();
-    var myExchange, myContentType, errorCalled;
-    request({
+
+    var exchange = request({
         url: baseUri,
         method: 'POST',
-        data: sendInputStream,
-        error: function() {
-            errorCalled = true;
-        },
-        complete: function(data, status, contentType, exchange) {
-            myExchange = exchange;
-            myContentType = contentType;
-        }
+        data: sendInputStream
     });
-    assert.isUndefined(errorCalled);
-    assert.isNotNull(myExchange);
-    assert.strictEqual(myExchange.contentBytes.length, inputByteArray.length);
-    assert.deepEqual(myExchange.contentBytes.toArray(), inputByteArray.toArray());
-    assert.strictEqual(myContentType, "image/png");
+    assert.isNotNull(exchange);
+    assert.strictEqual(exchange.contentBytes.length, inputByteArray.length);
+    assert.deepEqual(exchange.contentBytes.toArray(), inputByteArray.toArray());
+    assert.strictEqual(exchange.contentType, "image/png");
 };
 
 exports.testPost = function() {
@@ -448,44 +355,44 @@ exports.testPost = function() {
     var inputByteArray = data.toByteArray();
 
     // POSTing byte array
-    var req = request({
+    var exchange = request({
         url: baseUri,
         method: "POST",
         data: inputByteArray
     });
-    assert.strictEqual(req.status, 200);
-    assert.strictEqual(req.contentBytes.length, inputByteArray.length);
-    assert.deepEqual(req.contentBytes.toArray(), inputByteArray.toArray());
+    assert.strictEqual(exchange.status, 200);
+    assert.strictEqual(exchange.contentBytes.length, inputByteArray.length);
+    assert.deepEqual(exchange.contentBytes.toArray(), inputByteArray.toArray());
 
     // POSTing memory stream
-    req = request({
+    exchange = request({
         url: baseUri,
         method: "POST",
         data: new MemoryStream(inputByteArray)
     });
-    assert.strictEqual(req.status, 200);
-    assert.strictEqual(req.contentBytes.length, inputByteArray.length);
-    assert.deepEqual(req.contentBytes.toArray(), inputByteArray.toArray());
+    assert.strictEqual(exchange.status, 200);
+    assert.strictEqual(exchange.contentBytes.length, inputByteArray.length);
+    assert.deepEqual(exchange.contentBytes.toArray(), inputByteArray.toArray());
 
     // POSTing text stream
-    req = request({
+    exchange = request({
         url: baseUri,
         method: "POST",
         data: new TextStream(new MemoryStream(data.toByteString()), {charset: "utf-8"})
     });
-    assert.strictEqual(req.status, 200);
-    assert.strictEqual(req.contentBytes.length, inputByteArray.length);
-    assert.deepEqual(req.contentBytes.toArray(), inputByteArray.toArray());
+    assert.strictEqual(exchange.status, 200);
+    assert.strictEqual(exchange.contentBytes.length, inputByteArray.length);
+    assert.deepEqual(exchange.contentBytes.toArray(), inputByteArray.toArray());
 
     // POSTing java.io.InputStream
-    req = request({
+    exchange = request({
         url: baseUri,
         method: "POST",
         data: fs.openRaw(module.path).unwrap()
     });
-    assert.strictEqual(req.status, 200);
-    assert.strictEqual(req.contentBytes.length, inputByteArray.length);
-    assert.deepEqual(req.contentBytes.toArray(), inputByteArray.toArray());
+    assert.strictEqual(exchange.status, 200);
+    assert.strictEqual(exchange.contentBytes.length, inputByteArray.length);
+    assert.deepEqual(exchange.contentBytes.toArray(), inputByteArray.toArray());
 
     var resource = getResource('./upload_test.png');
     var inputStream = resource.getInputStream();
@@ -493,21 +400,13 @@ exports.testPost = function() {
     var size = resource.getLength();
     inputByteArray = new ByteArray(size);
     inputStream.read(inputByteArray, 0, size);
-    var errorCalled;
-    request({
+    exchange = request({
         url: baseUri,
         method: "POST",
-        data: resource.getInputStream(),
-        error: function() {
-            errorCalled = true;
-        },
-        complete: function(data, status, contentType, exchange) {
-            req = exchange;
-        }
+        data: resource.getInputStream()
     });
-    assert.isUndefined(errorCalled);
-    assert.strictEqual(inputByteArray.length, req.contentBytes.length);
-    assert.deepEqual(inputByteArray.toArray(), req.contentBytes.toArray());
+    assert.strictEqual(inputByteArray.length, exchange.contentBytes.length);
+    assert.deepEqual(inputByteArray.toArray(), exchange.contentBytes.toArray());
 };
 
 exports.testPostMultipart = function() {
@@ -567,33 +466,17 @@ exports.testProxiedRequest = function() {
         return response.html(text);
     };
 
-    var errorCalled, myData;
     var exchange = request({
         url: "http://idontexistandifigetcalledwithoutproxyshouldraiseerror.com",
         proxy: [host, ":", port].join(""),
-        success: function(data, status, contentType, exchange) {
-            myData = data;
-        },
-        error: function() {
-            errorCalled = true;
-        }
     });
-    assert.isUndefined(errorCalled);
-    assert.strictEqual(myData, text);
+    assert.strictEqual(exchange.content, text);
 
-    errorCalled = myData = undefined;
-    var exchange = request({
+    exchange = request({
         url: "http://idontexistandifigetcalledwithoutproxyshouldraiseerror.com",
-        proxy: {"host": host, "port": port},
-        success: function(data, status, contentType, exchange) {
-            myData = data;
-        },
-        error: function() {
-            errorCalled = true;
-        }
+        proxy: {"host": host, "port": port}
     });
-    assert.isUndefined(errorCalled);
-    assert.strictEqual(myData, text);
+    assert.strictEqual(exchange.content, text);
 };
 
 exports.testIterateExchange_Issue287 = function() {
@@ -606,16 +489,9 @@ exports.testIterateExchange_Issue287 = function() {
 
    var errorCalled, myData;
    var exchange = request({
-      url: baseUri,
-      success: function(data, status, contentType, exchange) {
-         myData = data;
-      },
-      error: function() {
-         errorCalled = true;
-      }
+      url: baseUri
    });
-   assert.isUndefined(errorCalled);
-   assert.strictEqual(myData, text);
+   assert.strictEqual(exchange.content, text);
 
    var clone = objects.clone(exchange.headers);
    assert.deepEqual(exchange.headers, clone);


### PR DESCRIPTION
As discussed in #267 and #310 this drops the callbacks and forces users to use a synchronous programming style. Since the client is blocking, this change will make the blocking behavior more visible.