### PR TITLE
Implements multiple HTTP header support

### DIFF
--- a/modules/ringo/httpclient.js
+++ b/modules/ringo/httpclient.js
@@ -397,7 +397,7 @@ Object.defineProperties(Exchange.prototype, {
             // this is required since ScriptableMap cannot deal with null keys!
             headerFields.remove(null);
 
-           return new ScriptableMap(headerFields);
+            return new ScriptableMap(headerFields);
         }, enumerable: true
     },
     /**

--- a/modules/ringo/jsgi/response.js
+++ b/modules/ringo/jsgi/response.js
@@ -168,8 +168,29 @@ Object.defineProperty(JsgiResponse.prototype, "setCharset", {
  * @returns {JsgiResponse} JSGI response with the new headers
  */
 Object.defineProperty(JsgiResponse.prototype, "addHeaders", {
-    value: function(headers) {
-        this.headers = merge(headers, this.headers);
+    value: function(additionalHeaders) {
+        for (let fieldName in additionalHeaders) {
+            let existingValues = this.headers[fieldName];
+
+            // check if the header is already set
+            if (existingValues === undefined) {
+                if (additionalHeaders[fieldName] instanceof Array) {
+                    // add multiple header values as an array of strings
+                    this.headers[fieldName] = additionalHeaders[fieldName].map(function(headerValue) {
+                        return String(headerValue);
+                    });
+                } else {
+                    // single-valued header as arbitrary string
+                    this.headers[fieldName] = String(additionalHeaders[fieldName]);
+                }
+            } else if (typeof existingValues === "string") {
+                // the header has been set already exactly once, so expand it to an array
+                this.headers[fieldName] = [existingValues, String(additionalHeaders[fieldName])];
+            } else {
+                // the header is already an array of multiple values --> push new value
+                this.headers[fieldName].push(String(additionalHeaders[fieldName]));
+            }
+        }
         return this;
     }
 });

--- a/modules/ringo/utils/http.js
+++ b/modules/ringo/utils/http.js
@@ -49,9 +49,11 @@ function sanitizeHeaderValue(fieldValue) {
 }
 
 /**
- * Returns an object for use as a HTTP header collection. The returned object
+ * Returns an object for use as a HTTP request header collection. The returned object
  * provides methods for setting, getting, and deleting its properties in a
- * case-insensitive and case-preserving way.
+ * case-insensitive and case-preserving way. Multiple headers with the same
+ * field name will be merged into a comma-separated string. Therefore the
+ * <code>Set-Cookie</code> header is not supported by this function.
  *
  * This function can be used as mixin for an existing JavaScript object or as a
  * constructor.

--- a/modules/ringo/utils/http.js
+++ b/modules/ringo/utils/http.js
@@ -42,6 +42,13 @@ function ResponseFilter(body, filter) {
 }
 
 /**
+ * @ignore interal function, following RFC 7230 section 3.2.2. field order
+ */
+function sanitizeHeaderValue(fieldValue) {
+    return fieldValue.replace(/\n/g, "").trim();
+}
+
+/**
  * Returns an object for use as a HTTP header collection. The returned object
  * provides methods for setting, getting, and deleting its properties in a
  * case-insensitive and case-preserving way.
@@ -76,7 +83,8 @@ function Headers(headers) {
             if (value === undefined) {
                 value = (key = keys[key.toLowerCase()]) && this[key];
             }
-            return value;
+
+            return (typeof value === "string" ? sanitizeHeaderValue(value) : value);
         }
     });
 
@@ -88,8 +96,7 @@ function Headers(headers) {
      */
     Object.defineProperty(headers, "set", {
         value: function(key, value) {
-            // JSGI uses \n as separator for mulitple headers
-            value = value.replace(/\n/g, "");
+            value = sanitizeHeaderValue(value);
             var oldkey = keys[key.toLowerCase()];
             if (oldkey) {
                 delete this[oldkey];
@@ -107,17 +114,16 @@ function Headers(headers) {
      */
     Object.defineProperty(headers, "add", {
         value: function(key, value) {
-            // JSGI uses \n as separator for mulitple headers
-            value = value.replace(/\n/g, "");
+            value = sanitizeHeaderValue(value);
             if (this[key]) {
                 // shortcut
-                this[key] = this[key] + "\n" + value;
+                this[key] = this[key] + "," + value;
                 return;
             }
             var lowerkey = key.toLowerCase();
             var oldkey = keys[lowerkey];
             if (oldkey) {
-                value = this[oldkey] + "\n" + value;
+                value = this[oldkey] + "," + value;
                 if (key !== oldkey)
                     delete this[oldkey];
             }
@@ -149,7 +155,7 @@ function Headers(headers) {
         value: function(key) {
            key = key.toLowerCase();
             if (key in keys) {
-                delete this[keys[key]]
+                delete this[keys[key]];
                 delete keys[key];
             }
         }

--- a/test/integration-tests/all.js
+++ b/test/integration-tests/all.js
@@ -25,6 +25,7 @@ exports.testJarsToClasspath = function() {
 };
 
 exports.testRequireMain = require("./require-index/main").testCalculator;
+exports.testHttpJsgiBinding = require("./http-jsgi-binding/simple").testHttpJsgiBinding;
 
 // start the test runner if we're called directly from command line
 if (require.main === module) {

--- a/test/integration-tests/http-jsgi-binding/simple.js
+++ b/test/integration-tests/http-jsgi-binding/simple.js
@@ -1,0 +1,71 @@
+const assert = require("assert");
+
+const {get, request} = require("ringo/httpclient");
+const {Server} = require("ringo/httpserver");
+
+const {JsgiResponse} = require("ringo/jsgi/response");
+
+const HOST = "127.0.0.1";
+const PORT = 8088;
+
+exports.testHttpJsgiBinding = function() {
+    let server;
+    try {
+        server = new Server({
+            "host": HOST,
+            "port": PORT
+        });
+
+        const app = function (req) {
+            if (req.pathInfo === "/") {
+                return {
+                    status: 200,
+                    headers: {
+                        "Content-Type": "text/plain",
+                        "Set-Cookie": ["foo=1; Path=/", "bar=2; Path=/baz"]
+                    },
+                    body: ["Hello World!"]
+                };
+            } else if (req.pathInfo === "/jsgiresponse") {
+                return new JsgiResponse().text("foo").addHeaders({
+                    "foo": "bar",
+                    "mufoo": ["bar", "baz", 12345]
+                });
+            } else if (req.pathInfo === "/multipleheaders") {
+                return new JsgiResponse().text("done");
+            }
+        };
+
+        server.getDefaultContext().serveApplication(app);
+        server.start();
+
+        let exchange = get("http://" + HOST + ":" + PORT + "/");
+        assert.equal(exchange.status, 200);
+        assert.isTrue(exchange.headers["Set-Cookie"] instanceof Array);
+        assert.isTrue(exchange.headers["Set-Cookie"].indexOf("foo=1; Path=/") >= 0);
+        assert.isTrue(exchange.headers["Set-Cookie"].indexOf("bar=2; Path=/baz") >= 0);
+
+        exchange = get("http://" + HOST + ":" + PORT + "/jsgiresponse");
+        assert.equal(exchange.status, 200);
+        assert.equal(exchange.headers["foo"][0], "bar");
+        assert.isTrue(exchange.headers["mufoo"] instanceof Array);
+        assert.isTrue(exchange.headers["mufoo"].indexOf("bar") >= 0);
+        assert.isTrue(exchange.headers["mufoo"].indexOf("baz") >= 0);
+        assert.isTrue(exchange.headers["mufoo"].indexOf("12345") >= 0);
+
+        exchange = request({
+            url: "http://" + HOST + ":" + PORT + "/multipleheaders",
+            method: "GET",
+            headers: {
+                "mufoo": ["bar", "baz", "12345"]
+            }
+        });
+        assert.equal(exchange.status, 200);
+    } finally {
+        server.stop();
+    }
+};
+
+if (require.main === module) {
+    require("system").exit(require("test").run(module.id));
+}

--- a/test/ringo/httpclient_test.js
+++ b/test/ringo/httpclient_test.js
@@ -3,7 +3,7 @@ var objects = require("ringo/utils/objects");
 var {Server} = require("ringo/httpserver");
 var response = require("ringo/jsgi/response");
 var {request, post, get, put, del, TextPart, BinaryPart} = require("ringo/httpclient");
-var {parseParameters, parseFileUpload, setCookie} = require("ringo/utils/http");
+var {parseParameters, parseFileUpload, setCookie, Headers} = require("ringo/utils/http");
 var {MemoryStream, TextStream} = require("io");
 var fs = require("fs");
 var base64 = require("ringo/base64");
@@ -549,6 +549,24 @@ exports.testNoCallbacks = function() {
 
     assert.isFalse(anyCallbackCalled, "Callback has been called!");
     assert.strictEqual(exchange.status, 200);
+};
+
+exports.testMultipleHeaders_Issue225 = function() {
+    getResponse = function(req) {
+        assert.equal(req.env.servletRequest.getHeader("single-header"), "one", "Header not present");
+        assert.equal(req.env.servletRequest.getHeader("multiple-header"), "one,two", "Multiple headers not merged into one");
+        return response.text("done");
+    };
+
+    let preparedHeaders = Headers({});
+    preparedHeaders.set("single-header", "one");
+    preparedHeaders.add("multiple-header", "one");
+    preparedHeaders.add("multiple-header", "two");
+
+    var exchange = request({
+        url: baseUri,
+        headers: preparedHeaders
+    });
 };
 
 // start the test runner if we're called directly from command line

--- a/test/ringo/httpserver_test.js
+++ b/test/ringo/httpserver_test.js
@@ -177,13 +177,8 @@ exports.testMultipleHeaders = function () {
         assert.equal(req.scheme, "http");
 
         assert.equal(req.headers.host, host + ":" + port); // This follows RFC 2616!
-        assert.equal(req.headers["x-foo"], "bar");
-
-        var headersArray = [];
-        for (var headers = req.env.servletRequest.getHeaders("x-foo"); headers.hasMoreElements(); ) {
-            headersArray.push(headers.nextElement());
-        }
-        assert.equal("bar, baz, 012345;q=15", headersArray.join(", "));
+        assert.equal(req.headers["x-foo-single"], "single-bar");
+        assert.equal(req.headers["x-foo"], "bar,baz,012345;q=15");
     };
 
     var connection = (new java.net.URL(baseUri)).openConnection();

--- a/test/ringo/jsgi/response_test.js
+++ b/test/ringo/jsgi/response_test.js
@@ -183,6 +183,36 @@ exports.testAddHeaders = function () {
     });
 
     assert.deepEqual(res.addHeaders({"x-foo": "bar", boo: "far", "x-limit": "100"}), expected);
+
+    // multiple headers chained
+    res = new JsgiResponse();
+    res.addHeaders({ foo: "bar" }).addHeaders({ foo: "baz" }).addHeaders({ foo: 12345 });
+    assert.deepEqual(res.headers,  {
+        "content-type": "text/plain; charset=utf-8",
+        "foo": ["bar", "baz", "12345"]
+    });
+    assert.isTrue(Array.isArray(res.headers.foo));
+    assert.isTrue(res.headers.foo.indexOf("bar") >= 0);
+    assert.isTrue(res.headers.foo.indexOf("baz") >= 0);
+    assert.isTrue(res.headers.foo.indexOf("12345") >= 0);
+    assert.isTrue(res.headers.foo.every(function(val) {
+        return typeof val === "string";
+    }))
+
+    // multiple headers as array
+    res = new JsgiResponse();
+    res.addHeaders({ foo: ["bar", "baz", 12345] });
+    assert.deepEqual(res.headers,  {
+        "content-type": "text/plain; charset=utf-8",
+        "foo": ["bar", "baz", "12345"]
+    });
+    assert.isTrue(Array.isArray(res.headers.foo));
+    assert.isTrue(res.headers.foo.indexOf("bar") >= 0);
+    assert.isTrue(res.headers.foo.indexOf("baz") >= 0);
+    assert.isTrue(res.headers.foo.indexOf("12345") >= 0);
+    assert.isTrue(res.headers.foo.every(function(val) {
+        return typeof val === "string";
+    }))
 };
 
 exports.testHelpers = function() {

--- a/test/ringo/utils/http_test.js
+++ b/test/ringo/utils/http_test.js
@@ -265,6 +265,49 @@ exports.testSetCookie = function() {
     );
 };
 
+exports.testHeadersOnObject = function() {
+    let obj = {
+        "One": "ValueOne",
+        "two": "ValueTwo",
+        "THREE": "  Value\nThree  "
+    };
+
+    http.Headers(obj);
+    assert.equal(obj.get("one"), "ValueOne", "Unexpected value returned by header");
+    assert.equal(obj.get("One"), "ValueOne", "Unexpected value returned by header");
+    assert.equal(obj.get("two"), "ValueTwo", "Unexpected value returned by header");
+    assert.equal(obj.get("three"), "ValueThree", "Unexpected value returned by header");
+    assert.equal(obj.get("THREE"), "ValueThree", "Unexpected value returned by header");
+    assert.equal(obj.get("ThReE"), "ValueThree", "Unexpected value returned by header");
+
+    obj.set("ONE", "SecondValue");
+    assert.equal(obj.get("one"), "SecondValue", "Unexpected value returned by header");
+
+    obj.add("Four", "ValueFour");
+    assert.equal(obj.get("four"), "ValueFour", "Unexpected value returned by header");
+
+    assert.isTrue(obj.contains("ONE"), "Headers should contain one");
+    assert.isTrue(obj.contains("TWO"), "Headers should contain two");
+    assert.isTrue(obj.contains("three"), "Headers should contain three");
+    assert.isTrue(obj.contains("four"), "Headers should contain four");
+
+    obj.unset("ONE");
+    assert.isUndefined(obj.get("one"), "Header value not unset");
+};
+
+exports.testHeadersMultipleNames = function() {
+    let obj = {
+        "single": "simplevalue",
+        "multiple": "first"
+    };
+
+    http.Headers(obj);
+    obj.add("multiple", "second");
+    assert.equal(obj.get("multiple"), "first,second", "Multiple headers not merged!");
+    obj.add("multiple", "third");
+    assert.equal(obj.get("multiple"), "first,second,third", "Multiple headers not merged!");
+};
+
 if (require.main === module) {
     require('system').exit(require("test").run(module.id));
 }


### PR DESCRIPTION
* `ringo/jsgi/response` switches to an array if multiple headers are present
* The JsgiServlet merges multiple headers into one single line according to the HTTP spec section 4.2

This fixes #225 