### PR TITLE
Resolve ModuleLoader.java's File descriptor leak points

### DIFF
--- a/src/org/ringojs/engine/ModuleLoader.java
+++ b/src/org/ringojs/engine/ModuleLoader.java
@@ -61,12 +61,11 @@ class JsModuleLoader extends ModuleLoader {
             throws Exception {
         return AccessController.doPrivileged(new PrivilegedAction<Object>() {
             public Object run() {
-				InputStream aStream = null;
+                InputStream aStream = null;
                 InputStreamReader aReader = null;
                 try {
-					aStream = resource.getInputStream();
+                    aStream = resource.getInputStream();
                     aReader = new InputStreamReader(aStream, charset);
-					
                     return cx.compileReader(aReader,
                             resource.getRelativePath(),
                             resource.getLineNumber(), securityDomain);
@@ -122,25 +121,24 @@ class ClassModuleLoader extends ModuleLoader {
         int length = (int) l;
         byte[] bytes = new byte[length];
         InputStream input = resource.getInputStream();
-		try{
-			int offset = 0, read;
+        try{
+            int offset = 0, read;
 
-			while (offset < length) {	
-				read = input.read(bytes, offset, length - offset);
-				if (read < 0) break;
-				offset += read;
-			}
+            while (offset < length) {
+                read = input.read(bytes, offset, length - offset);
+                if (read < 0) break;
+                offset += read;
+            }
 
-			if (offset < length) {
-				throw new IOException("Could not read file completely");
-			}
-		}catch(IOException e){
-			throw e;
-		}finally{
-			// releases system resources associated with this stream
-			if(input != null)
-				input.close();
-		}
+            if (offset < length) {
+                throw new IOException("Could not read file completely");
+            }
+        }catch(IOException e){
+            throw e;
+        }finally{
+            if(input != null)
+                input.close();
+        }
         
 
         String className = moduleName.replaceAll("/", ".");

--- a/src/org/ringojs/engine/ModuleLoader.java
+++ b/src/org/ringojs/engine/ModuleLoader.java
@@ -25,6 +25,7 @@ import org.mozilla.javascript.SecurityController;
 import org.mozilla.javascript.json.JsonParser;
 import org.ringojs.repository.Resource;
 
+import java.io.InputStreamReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.AccessController;
@@ -60,12 +61,28 @@ class JsModuleLoader extends ModuleLoader {
             throws Exception {
         return AccessController.doPrivileged(new PrivilegedAction<Object>() {
             public Object run() {
+				InputStream aStream = null;
+                InputStreamReader aReader = null;
                 try {
-                    return cx.compileReader(resource.getReader(charset),
+					aStream = resource.getInputStream();
+                    aReader = new InputStreamReader(aStream, charset);
+					
+                    return cx.compileReader(aReader,
                             resource.getRelativePath(),
                             resource.getLineNumber(), securityDomain);
                 } catch (IOException iox) {
                     throw new RuntimeException(iox);
+                } finally {
+                    if( aReader != null ) {
+                        try{
+                            aReader.close();    
+                        }catch(IOException iox){}
+                    }
+                    if( aStream != null ) {
+                        try{
+                            aStream.close();
+                        }catch(IOException iox){}
+                    }
                 }
             }
         });
@@ -105,18 +122,26 @@ class ClassModuleLoader extends ModuleLoader {
         int length = (int) l;
         byte[] bytes = new byte[length];
         InputStream input = resource.getInputStream();
-        int offset = 0, read;
+		try{
+			int offset = 0, read;
 
-        while (offset < length) {
-            read = input.read(bytes, offset, length - offset);
-            if (read < 0) break;
-            offset += read;
-        }
+			while (offset < length) {	
+				read = input.read(bytes, offset, length - offset);
+				if (read < 0) break;
+				offset += read;
+			}
 
-        if (offset < length) {
-            throw new IOException("Could not read file completely");
-        }
-        input.close();
+			if (offset < length) {
+				throw new IOException("Could not read file completely");
+			}
+		}catch(IOException e){
+			throw e;
+		}finally{
+			// releases system resources associated with this stream
+			if(input != null)
+				input.close();
+		}
+        
 
         String className = moduleName.replaceAll("/", ".");
         ClassLoader rhinoLoader = getClass().getClassLoader();


### PR DESCRIPTION
I suffered some File descriptor leaks (on ubuntu with jetty runner via .war deploy with production = true setting) on many various .js files when I use require function in Ringojs.

I cannot see any *.js File Descriptors after I closed some stream and reader instances.

I've tested this code only for Webapp repository environments.
This code must be tested for another repository types.

thank you.

p.s.: RingoJS is awesome! I cannot believe that I have many various ringo webapp deploy options!. Of-course, I love war deployment most!
