### PR TITLE
Allows middlewares to preserve & modify input stream

### DIFF
--- a/modules/ringo/jsgi/connector.js
+++ b/modules/ringo/jsgi/connector.js
@@ -69,9 +69,10 @@ function initRequest(request) {
             return input;
         },
         set: function(stream) {
-            if (stream instanceof Stream) {
-               input = stream;
+            if (!stream instanceof Stream) {
+               throw new Error("Input must be a Stream!");
             }
+            input = stream;
         },
         enumerable: true
     });

--- a/modules/ringo/jsgi/connector.js
+++ b/modules/ringo/jsgi/connector.js
@@ -68,6 +68,11 @@ function initRequest(request) {
                 input = new Stream(request.env.servletRequest.getInputStream());
             return input;
         },
+        set: function(stream) {
+            if (stream instanceof Stream) {
+               input = stream;
+            }
+        },
         enumerable: true
     });
     Object.defineProperty(request.jsgi, "errors", {


### PR DESCRIPTION
This would enable JSGI middlewares to read the input and reset the input stream to the initial state after. This is needed to add support for `X-Hub-Signature` like available for the Github and Facebook API. Otherwise someone needs to clone the whole params middleware to avoid that it consumes the input stream before the verification middleware.