### PR TITLE
Accept Content-Encoding values case-insensitive

### DIFF
--- a/modules/ringo/httpclient.js
+++ b/modules/ringo/httpclient.js
@@ -223,9 +223,9 @@ var readResponse = function(connection) {
         }
         var encoding = connection.getContentEncoding();
         if (encoding != null) {
-            if (encoding === "gzip") {
+            if (encoding.equalsIgnoreCase("gzip")) {
                 inStream = new GZIPInputStream(inStream);
-            } else if (encoding === "deflate") {
+            } else if (encoding.equalsIgnoreCase("deflate")) {
                 inStream = new InflaterInputStream(inStream);
             }
         }


### PR DESCRIPTION
According to the spec the value of the content-encoding header field
is case insensitive, therefor changed `readResponse()` to utilize
`equalsIgnoreCase()` when checking the content encoding.

See https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.5