### PR TITLE
Add new helpers to JSGI response module

### DIFF
--- a/modules/ringo/jsgi/response.js
+++ b/modules/ringo/jsgi/response.js
@@ -203,6 +203,8 @@ Object.defineProperty(JsgiResponse.prototype, "setCharset", {
 
 /**
  * Merge the given object into the headers of the JSGI response.
+ * Note that header field names are case-sensitive in the `JsgiResponse` object, whereas
+ * they are not in the final HTTP response message sent out by Jetty.
  * @param {Object} headers new header fields to merge with the current ones.
  * @returns {JsgiResponse} JSGI response with the new headers
  */
@@ -230,6 +232,27 @@ Object.defineProperty(JsgiResponse.prototype, "addHeaders", {
                 this.headers[fieldName].push(String(additionalHeaders[fieldName]));
             }
         }
+        return this;
+    }
+});
+
+/**
+ * Merge the given object into the headers of the JSGI response.
+ * Existing headers in the to-be-sent headers will be replaced with the new ones.
+ * Note that header field names are case-sensitive in the `JsgiResponse` object, whereas
+ * they are not in the final HTTP response message sent out by Jetty.
+ * @param {Object} headers new headers to be set
+ * @returns {JsgiResponse} JSGI response with the new headers
+ */
+Object.defineProperty(JsgiResponse.prototype, "setHeaders", {
+    value: function(headersToSet) {
+        // delete already existing headers
+        for (let fieldName in headersToSet) {
+            if (this.headers[fieldName] !== undefined) {
+                delete this.headers[fieldName];
+            }
+        }
+        this.addHeaders(headersToSet);
         return this;
     }
 });
@@ -512,7 +535,7 @@ Object.defineProperty(JsgiResponse.prototype, "notModified", {
 
 // Define helper functions
 /** @ignore */
-["setStatus", "text", "html", "json", "jsonp", "xml", "stream", "binary", "setCharset", "addHeaders",
+["setStatus", "text", "html", "json", "jsonp", "xml", "stream", "binary", "setCharset", "addHeaders", "setHeaders",
     "ok", "created", "bad", "unauthorized", "forbidden", "notFound", "gone", "error",
     "unavailable", "redirect", "notModified"].forEach(function(functionName) {
     exports[functionName] = function() {

--- a/modules/ringo/jsgi/response.js
+++ b/modules/ringo/jsgi/response.js
@@ -202,6 +202,18 @@ Object.defineProperty(JsgiResponse.prototype, "setCharset", {
 });
 
 /**
+ * Set the content type for the current response.
+ * @param {String} contentType the content type header value.
+ * @returns {JsgiResponse} JSGI response with the given charset
+ */
+Object.defineProperty(JsgiResponse.prototype, "setContentType", {
+    value: function(contentType) {
+        this.headers["content-type"] = String(contentType);
+        return this;
+    }
+});
+
+/**
  * Merge the given object into the headers of the JSGI response.
  * Note that header field names are case-sensitive in the `JsgiResponse` object, whereas
  * they are not in the final HTTP response message sent out by Jetty.
@@ -446,10 +458,27 @@ Object.defineProperty(JsgiResponse.prototype, "notModified", {
  */
 
 /**
+ * Set the content type for the current response.
+ * @param {String} contentType the content type header value.
+ * @returns {JsgiResponse} JSGI response with the given charset
+ * @name setContentType
+ * @function
+ */
+
+/**
  * Merge the given object into the headers of the JSGI response.
  * @param {Object} headers new header fields to merge with the current ones.
  * @returns {JsgiResponse} JSGI response with the new headers
  * @name addHeaders
+ * @function
+ */
+
+/**
+ * Merge the given object into the headers of the JSGI response.
+ * Existing headers in the to-be-sent headers will be replaced with the new ones.
+ * @param {Object} headers new headers to be set
+ * @returns {JsgiResponse} JSGI response with the new headers
+ * @name setHeaders
  * @function
  */
 
@@ -536,7 +565,7 @@ Object.defineProperty(JsgiResponse.prototype, "notModified", {
 // Define helper functions
 /** @ignore */
 ["setStatus", "text", "html", "json", "jsonp", "xml", "stream", "binary", "setCharset", "addHeaders", "setHeaders",
-    "ok", "created", "bad", "unauthorized", "forbidden", "notFound", "gone", "error",
+    "setContentType", "ok", "created", "bad", "unauthorized", "forbidden", "notFound", "gone", "error",
     "unavailable", "redirect", "notModified"].forEach(function(functionName) {
     exports[functionName] = function() {
         return JsgiResponse.prototype[functionName].apply((new JsgiResponse()), arguments);

--- a/test/ringo/jsgi/response_test.js
+++ b/test/ringo/jsgi/response_test.js
@@ -328,6 +328,27 @@ exports.testSetHeaders = function () {
     assert.isTrue(typeof res.headers.Foo === "string");
 };
 
+exports.testSetContentType = function () {
+    var res = new JsgiResponse();
+
+    var expected = new JsgiResponse({
+        status: 200,
+        headers: {
+            "content-type": "foo/bar; charset=utf-16"
+        },
+        body: [""]
+    });
+
+    assert.deepEqual(res.setContentType("foo/bar; charset=utf-16"), expected);
+
+    res = new JsgiResponse();
+    res.html("<h1>Hello World!</h1>").setContentType("text/myplain; charset=utf-16");
+    assert.deepEqual(res.headers,  {
+        "content-type": "text/myplain; charset=utf-16"
+    });
+    assert.deepEqual(res.body, ["<h1>Hello World!</h1>"]);
+};
+
 exports.testHelpers = function() {
     var response = require("ringo/jsgi/response");
 

--- a/test/ringo/jsgi/response_test.js
+++ b/test/ringo/jsgi/response_test.js
@@ -255,7 +255,77 @@ exports.testAddHeaders = function () {
     assert.isTrue(res.headers.foo.indexOf("12345") >= 0);
     assert.isTrue(res.headers.foo.every(function(val) {
         return typeof val === "string";
-    }))
+    }));
+
+    // case test
+    res = new JsgiResponse();
+    res.addHeaders({ foo: "bar" }).addHeaders({ FOO: "baz" }).addHeaders({ Foo: 12345 });
+    assert.deepEqual(res.headers,  {
+        "content-type": "text/plain; charset=utf-8",
+        "foo": "bar",
+        "FOO": "baz",
+        "Foo": 12345
+    });
+    assert.isTrue(typeof res.headers.Foo === "string");
+};
+
+exports.testSetHeaders = function () {
+    var res = new JsgiResponse();
+
+    var expected = new JsgiResponse({
+        status: 200,
+        headers: {
+            "content-type": "text/plain; charset=utf-8",
+            "x-foo": "bar",
+            "boo": "far",
+            "x-limit": "100"
+        },
+        body: [""]
+    });
+
+    assert.deepEqual(res.setHeaders({"x-foo": "bar", boo: "far", "x-limit": "100"}), expected);
+    assert.deepEqual(res.setHeaders({"x-foo": "bar", boo: "far", "x-limit": "100"}), expected);
+
+    // multiple headers chained
+    res = new JsgiResponse();
+    res.setHeaders({ foo: "bar" }).setHeaders({ foo: "baz" }).setHeaders({ foo: 12345 });
+    assert.deepEqual(res.headers,  {
+        "content-type": "text/plain; charset=utf-8",
+        "foo": "12345"
+    });
+    assert.isTrue(typeof res.headers.foo === "string");
+
+    // multiple headers as array
+    res = new JsgiResponse();
+    res.setHeaders({ foo: ["bar", "baz", 12345] });
+    assert.deepEqual(res.headers,  {
+        "content-type": "text/plain; charset=utf-8",
+        "foo": ["bar", "baz", "12345"]
+    });
+    assert.isTrue(Array.isArray(res.headers.foo));
+    assert.isTrue(res.headers.foo.indexOf("bar") >= 0);
+    assert.isTrue(res.headers.foo.indexOf("baz") >= 0);
+    assert.isTrue(res.headers.foo.indexOf("12345") >= 0);
+    assert.isTrue(res.headers.foo.every(function(val) {
+        return typeof val === "string";
+    }));
+
+    res.setHeaders({ foo: ["moo", "maa", 67890] });
+    assert.deepEqual(res.headers,  {
+        "content-type": "text/plain; charset=utf-8",
+        "foo": ["moo", "maa", "67890"]
+    });
+
+    // case test
+    res = new JsgiResponse();
+    res.setHeaders({ foo: "bar" }).setHeaders({ FOO: "baz" }).setHeaders({ Foo: 12345 });
+    assert.deepEqual(res.headers,  {
+        "content-type": "text/plain; charset=utf-8",
+        "foo": "bar",
+        "FOO": "baz",
+        "Foo": 12345
+    });
+    assert.isTrue(typeof res.headers.Foo === "string");
 };
 
 exports.testHelpers = function() {


### PR DESCRIPTION
This fixes #371 and adds `setHeaders()` and `setContentType()`