### PR TITLE
Adapt to Rhino's NativePromise

### DIFF
--- a/src/org/ringojs/engine/RingoGlobal.java
+++ b/src/org/ringojs/engine/RingoGlobal.java
@@ -217,7 +217,9 @@ public class RingoGlobal extends Global {
             public Object call() {
                 return cxfactory.call(new ContextAction<Object>() {
                     public Object run(Context cx) {
-                        return function.call(cx, scope, scope, fnArgs);
+                        Object result = function.call(cx, scope, scope, fnArgs);
+                        cx.processMicrotasks();
+                        return result;
                     }
                 });
             }

--- a/src/org/ringojs/engine/RingoWorker.java
+++ b/src/org/ringojs/engine/RingoWorker.java
@@ -126,6 +126,7 @@ public final class RingoWorker {
             }
         } finally {
             releaseWorker(previous);
+            cx.processMicrotasks();
             Context.exit();
         }
     }

--- a/test/all.js
+++ b/test/all.js
@@ -22,6 +22,7 @@ exports.testBinary         = require('./binary/all');
 exports.testRepository     = require('./repository/all');
 exports.testIo             = require('./io_test');
 exports.testModules        = require('./modules/all');
+exports.testRhino          = require("./rhino/all");
 
 // Also include integration tests
 exports.testIntegration    = require('./integration-tests/all');

--- a/test/rhino/all.js
+++ b/test/rhino/all.js
@@ -1,0 +1,4 @@
+exports.testArrowFunctions = require("./arrow_functions");
+exports.testConstStatement = require("./const_statement");
+exports.testLetStatement = require("./let_statement");
+exports.testPromise = require("./promise_test");

--- a/test/rhino/promise_test.js
+++ b/test/rhino/promise_test.js
@@ -1,0 +1,22 @@
+const assert = require("assert");
+const {Semaphore} = require("ringo/concurrent");
+
+exports.testResolve = () => {
+    const semaphore = new Semaphore();
+    let expected = false;
+    spawn(() => {
+        return new Promise(resolve => {
+            java.lang.Thread.sleep(100);
+            resolve(true);
+        }).then(value => {
+            expected = value;
+            semaphore.signal();
+        });
+    });
+    semaphore.tryWait(150);
+    assert.isTrue(expected);
+};
+
+if (require.main === module) {
+    require("system").exit(require("test").run(module.id));
+}


### PR DESCRIPTION
When directly calling Function objects `processMicrotasks` must be called before exiting the current context, otherwise pending promises won't be settled (see [1])

Found just two places in Ringo where calling `processMicrotasks` is necessary, but i might have missed some. Added a very basic test and enabled three other rhino tests that weren't executed by default (dunno why).

[1] https://github.com/mozilla/rhino/blob/master/src/org/mozilla/javascript/Context.java#L2326