### PR TITLE
fixes shell completion

### DIFF
--- a/modules/ringo/shell.js
+++ b/modules/ringo/shell.js
@@ -27,6 +27,7 @@ const styles = {
     'function': term.CYAN,
     'boolean': term.YELLOW,
     'null': term.BOLD,
+    'undefined': term.LIGHT_GREY,
     'date': term.MAGENTA,
     'java': term.MAGENTA,
     'custom': term.RED
@@ -187,7 +188,7 @@ const convert = (value, nesting, visited) => {
             }
             break;
         case 'undefined':
-            retval = {};
+            retval.type = retval.string = 'undefined';
             break;
         default:
             retval.string = String(value);
@@ -201,11 +202,9 @@ const convert = (value, nesting, visited) => {
  * @param {Stream} writer
  */
 const printResult = exports.printResult = (value, writer) => {
-    if (typeof value !== "undefined") {
-        writer = writer || term;
-        printValue(convert(value, 0, []), writer, 0);
-        writer.writeln();
-    }
+    writer = writer || term;
+    printValue(convert(value, 0, []), writer, 0);
+    writer.writeln();
 };
 
 const printValue = (value, writer, nesting) => {

--- a/modules/ringo/term.js
+++ b/modules/ringo/term.js
@@ -54,6 +54,8 @@ exports.ONMAGENTA = "\u001B[45m";
 exports.ONCYAN =    "\u001B[46m";
 exports.ONWHITE =   "\u001B[47m";
 
+exports.LIGHT_GREY = "\u001B[38;5;242;1m";
+
 // used to remove ANSI control sequences if disabled
 const cleaner = /\u001B\[\d*(?:;\d+)?[a-zA-Z]/g;
 // used to check if a string consists only of ANSI control sequences

--- a/src/org/ringojs/engine/ModuleScope.java
+++ b/src/org/ringojs/engine/ModuleScope.java
@@ -43,11 +43,7 @@ public class ModuleScope extends ImporterTopLevel {
         delete("constructor");
         // for activating the ImporterTopLevel import* functions
         activatePrototypeMap(3);
-        try {
-            cacheBuiltins(this, false);
-        } catch (NoSuchMethodError e) {
-            // allows us to run with older versions of Rhino
-        }
+        cacheBuiltins(this, false);
         this.source = source;
         this.repository = source instanceof Repository ?
                 (Repository) source : source.getParentRepository();

--- a/src/org/ringojs/engine/RhinoEngine.java
+++ b/src/org/ringojs/engine/RhinoEngine.java
@@ -16,15 +16,7 @@
 
 package org.ringojs.engine;
 
-import org.mozilla.javascript.Context;
-import org.mozilla.javascript.Function;
-import org.mozilla.javascript.JavaScriptException;
-import org.mozilla.javascript.ScriptRuntime;
-import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
-import org.mozilla.javascript.Undefined;
-import org.mozilla.javascript.WrapFactory;
-import org.mozilla.javascript.Wrapper;
+import org.mozilla.javascript.*;
 import org.mozilla.javascript.json.JsonParser;
 import org.ringojs.repository.*;
 import org.ringojs.tools.RingoDebugger;
@@ -262,7 +254,7 @@ public class RhinoEngine implements ScopeProvider {
     }
 
     /**
-     * Associate a worker with the current worker and return the worker
+     * Associate a worker with the current thread and return the worker
      * that was previously associated with it, or null.
      *
      * @param worker the new worker associated with the current thread
@@ -385,12 +377,7 @@ public class RhinoEngine implements ScopeProvider {
         Repository repository = new FileRepository("");
         repository.setAbsolute(true);
         Scriptable protoScope = mainScope != null ? mainScope : globalScope;
-        contextFactory.enterContext();
-        try {
-            return new ModuleScope("<shell>", repository, protoScope, worker);
-        } finally {
-            Context.exit();
-        }
+        return contextFactory.call(cx -> new ModuleScope("<shell>", repository, protoScope, worker));
     }
 
     /**

--- a/src/org/ringojs/engine/RingoWorker.java
+++ b/src/org/ringojs/engine/RingoWorker.java
@@ -131,6 +131,15 @@ public final class RingoWorker {
         }
     }
 
+    public Object getProperty(Scriptable obj, String name) {
+        RingoWorker previous = acquireWorker();
+        try {
+            return ScriptableObject.getProperty(obj, name);
+        } finally {
+            releaseWorker(previous);
+        }
+    }
+
     /**
      * <p>Submit a function to be invoked on the worker's event loop thread and
      * return a future for the result.</p>


### PR DESCRIPTION
retrieving completion candidates failed if a global property getter used `require()` (i.e. `console`) because the global scope doesn't have a worker attached.

this fix introduces a new method `getProperty` in `RingoWorker` class to ensure there's a worker bound to the current thread before retrieving completion candidates using `ScriptableObject.getProperty` as this method executes getter functions.

other notable changes:
- disable history expansion in terminal because `!` would be interpreted as backwards history search
- don't limit completion candidate retrieval, as jline3 prompts if there are many of them
- don't omit printing out `undefined` return values, instead print them using a light grey color, and omit executing empty lines in shell