### PR TITLE
Implements `system.properties`, fixes #456

### DIFF
--- a/modules/globals.js
+++ b/modules/globals.js
@@ -340,9 +340,14 @@ Object.defineProperty(this, "global", { value: this });
  */
 
 /**
- * The `environment` object contains the Java system properties.
+ * The `environment` object contains the Java system properties and is specific to the Rhino engine.
+ * Java system properties are set on the command line using the `-Dproperty=value` syntax and
+ * can be modified during the runtime. They do not relate to the operating system's environment variables.
+ * Because of the misleading name of this global property, using [system.properties](../system#properties)
+ * is recommended.
  * @name environment
  * @see <a href="http://docs.oracle.com/javase/tutorial/essential/environment/sysprop.html">Java System Properties</a>
+ * @deprecated Use the `system` module's `properties` and `env` exports instead.
  */
 
 /**

--- a/modules/system.js
+++ b/modules/system.js
@@ -95,9 +95,33 @@ exports.args = global.arguments || [];
  *   LOCALAPPDATA: 'C:\Local',
  *   ...
  * }
- * @see <a href="http://docs.oracle.com/javase/8/docs/api/java/lang/System.html#getenv()">java.lang.System.getenv()</a>
+ * @see <a href="https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/System.html#getenv()">java.lang.System.getenv()</a>
  */
 exports.env = new ScriptableMap(System.getenv());
+
+/**
+ * @name properties
+ * Returns an unmodifiable view on the current Java system properties.
+ * @example {
+ *   gopherProxySet: 'false',
+ *   awt.toolkit: 'sun.lwawt.macosx.LWCToolkit',
+ *   java.specification.version: '11',
+ *   sun.cpu.isalist: '',
+ *   sun.jnu.encoding: 'UTF-8',
+ *   java.class.path: '/Users/nobody/ringojs/run.jar',
+ *   java.vm.vendor: 'Eclipse Adoptium',
+ *   sun.arch.data.model: '64',
+ *   java.vendor.url: 'https://adoptium.net/',
+ *   user.timezone: 'Europe/Vienna',
+ *   ...
+ * }
+ * @see <a href="https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/System.html#getProperties()">java.lang.System.getProperties()</a>
+ */
+Object.defineProperty(exports, "properties", {
+    get: () => {
+        return new ScriptableMap(java.util.Collections.unmodifiableMap(System.getProperties()));
+    }
+});
 
 /**
  * Terminates the current process.

--- a/src/org/ringojs/engine/RingoGlobal.java
+++ b/src/org/ringojs/engine/RingoGlobal.java
@@ -86,8 +86,10 @@ public class RingoGlobal extends Global {
                                  ScriptableObject.DONTENUM);
         defineProperty("require", new Require(engine, this), DONTENUM);
         defineProperty("arguments", cx.newArray(this, engine.getArguments()), DONTENUM);
+
         // Set up "environment" in the global scope to provide access to the
-        // System environment variables. http://github.com/ringo/ringojs/issues/#issue/88
+        // System environment variables. https://github.com/ringo/ringojs/issues/88
+        // DEPRECATED beginning with Ringo 4.x: https://github.com/ringo/ringojs/issues/456
         Environment.defineClass(this);
         Environment environment = new Environment(this);
         defineProperty("environment", environment, ScriptableObject.DONTENUM);

--- a/test/all.js
+++ b/test/all.js
@@ -26,6 +26,7 @@ exports.testRepository     = require('./repository/all');
 exports.testIo             = require('./io_test');
 exports.testModules        = require('./modules/all');
 exports.testRhino          = require("./rhino/all");
+exports.testSystem         = require('./system_test');
 
 // Also include integration tests.
 exports.testIntegration    = require('./integration-tests/all');

--- a/test/system_test.js
+++ b/test/system_test.js
@@ -1,0 +1,33 @@
+const system = require("system");
+const assert = require("assert");
+
+exports.testEnv = function() {
+    assert.throws(() => {
+        system.env.foo = "bar";
+    });
+    assert.throws(() => {
+        system.env.foo = {};
+    });
+}
+
+exports.testProperties = function() {
+    assert.throws(() => {
+        system.properties.foo = "bar";
+    });
+    assert.throws(() => {
+        system.properties.foo = {};
+    });
+
+    assert.isTrue(typeof system.properties["java.version"] === "string");
+
+    assert.isUndefined(system.properties["system.test"]);
+    java.lang.System.setProperty("system.test", "running");
+    assert.strictEqual(system.properties["system.test"], "running");
+    java.lang.System.clearProperty("system.test");
+    assert.isUndefined(system.properties["system.test"]);
+};
+
+if (require.main === module) {
+    system.exit(require("test").run.apply(null,
+        [exports].concat(system.args.slice(1))));
+}


### PR DESCRIPTION
This implements a read-only `system.properties` export in the system module. The property is unmodifiable to prevent something like this:

```
// System properties must be strings!
system.properties.foo = {};
``` 